### PR TITLE
Speed-up query generation (DM-7113)

### DIFF
--- a/bin/ap_proto
+++ b/bin/ap_proto
@@ -22,7 +22,7 @@ import sys
 #-----------------------------
 # Imports for other modules --
 #-----------------------------
-from lsst.l1dbproto import constants, DIA, generators, l1db
+from lsst.l1dbproto import constants, DIA, generators, l1db, timer
 from lsst.sphgeom import htmIndex, LonLat, UnitVector3d, Vector3d
 
 #---------------------
@@ -147,62 +147,73 @@ class APProto(object):
         visitTimes = _visitTimes(self.args.start_time, self.args.interval, self.args.num_visits)
         for visit_id, dt in enumerate(visitTimes, self.args.start_visit_id):
 
-            _LOG.info("Processing visit %s at %s", visit_id, dt)
+            _LOG.info("+++ Start processing visit %s at %s", visit_id, dt)
+            loop_timer = timer.Timer().start()
 
-            # point telescope in random southern direction
-            pointing_xyz = generators.rand_sphere_xyz(1, -1)[0]
-            pointing_v = Vector3d(pointing_xyz[0], pointing_xyz[1], pointing_xyz[2])
-            ra = LonLat.longitudeOf(pointing_v).asDegrees()
-            decl = LonLat.latitudeOf(pointing_v).asDegrees()
+            with timer.Timer("DIA"):
+                # point telescope in random southern direction
+                pointing_xyz = generators.rand_sphere_xyz(1, -1)[0]
+                pointing_v = Vector3d(pointing_xyz[0], pointing_xyz[1], pointing_xyz[2])
+                ra = LonLat.longitudeOf(pointing_v).asDegrees()
+                decl = LonLat.latitudeOf(pointing_v).asDegrees()
 
-            _LOG.info("Pointing ra, decl = %s, %s; xyz = %s", ra, decl, pointing_xyz)
+                _LOG.info("Pointing ra, decl = %s, %s; xyz = %s", ra, decl, pointing_xyz)
 
-            # Simulating difference image analysis
-            dia = DIA.DIA(pointing_xyz, constants.FOV_rad, var_sources,
-                          constants.N_FALSE_PER_VISIT + constants.N_TRANS_PER_VISIT)
-            sources, indices = dia.makeSources()
-            n_sources = len(sources)
-            _LOG.info("DIA generated %s sources", n_sources)
+                # Simulating difference image analysis
+                dia = DIA.DIA(pointing_xyz, constants.FOV_rad, var_sources,
+                              constants.N_FALSE_PER_VISIT + constants.N_TRANS_PER_VISIT)
+                sources, indices = dia.makeSources()
+                n_sources = len(sources)
+                _LOG.info("DIA generated %s sources", n_sources)
 
-            # print current database row counts
-            counts = db.tableRowCount()
-            for tbl in sorted(counts.keys()):
-                _LOG.info('%s row count: %s', tbl, counts[tbl])
+            # print current database row counts, this takes long time
+            # so only do it once in a while
+            if visit_id % 10 == 0:
+                counts = db.tableRowCount()
+                for tbl in sorted(counts.keys()):
+                    _LOG.info('%s row count: %s', tbl, counts[tbl])
 
-            # Retrieve DiaObjects (latest versions) from database for matching,
-            # this will produce wider coverage so further filtering is needed
-            latest_objects = db.getDiaObjects(pointing_xyz, constants.FOV_rad,
-                                              False, explain=self.args.explain)
-            _LOG.info('database found %s objects', len(latest_objects))
+            with timer.Timer("L1-read"):
 
-            # filter database obects to a mask
-            latest_objects = self._filterDiaObjects(latest_objects, pointing_xyz, constants.FOV_rad)
-            _LOG.info('after filtering %s objects', len(latest_objects))
+                # Retrieve DiaObjects (latest versions) from database for matching,
+                # this will produce wider coverage so further filtering is needed
+                latest_objects = db.getDiaObjects(pointing_xyz, constants.FOV_rad,
+                                                  False, explain=self.args.explain)
+                _LOG.info('database found %s objects', len(latest_objects))
 
-            # create all new DiaObjects
-            objects = self._makeDiaObjects(sources, indices, dt)
+                # filter database obects to a mask
+                latest_objects = self._filterDiaObjects(latest_objects, pointing_xyz, constants.FOV_rad)
+                _LOG.info('after filtering %s objects', len(latest_objects))
 
-            # do forced photometry on non-detected objects (extends objects)
-            self._forcedPhotometry(objects, latest_objects, dt)
+            with timer.Timer("S2O-matching"):
 
-            # store new versions of objects
-            db.storeDiaObjects(objects, dt, explain=self.args.explain)
+                # create all new DiaObjects
+                objects = self._makeDiaObjects(sources, indices, dt)
 
-            # Store all sources
-            srcs = self._makeDiaSources(sources, indices, visit_id)
+                # do forced photometry on non-detected objects (extends objects)
+                self._forcedPhotometry(objects, latest_objects, dt)
 
-            # store all sources
-            db.storeDiaSources(srcs, explain=self.args.explain)
+                # Store all sources
+                srcs = self._makeDiaSources(sources, indices, visit_id)
 
-            # make forced sources for every object
-            fsrcs = self._makeDiaForcedSources(objects, visit_id)
+                # make forced sources for every object
+                fsrcs = self._makeDiaForcedSources(objects, visit_id)
 
-            # store all forced sources
-            db.storeDiaForcedSources(fsrcs, explain=self.args.explain)
+            with timer.Timer("L1-store"):
+
+                # store new versions of objects
+                db.storeDiaObjects(objects, dt, explain=self.args.explain)
+
+                # store all sources
+                db.storeDiaSources(srcs, explain=self.args.explain)
+
+                # store all forced sources
+                db.storeDiaForcedSources(fsrcs, explain=self.args.explain)
 
             # store last visit info
             db.saveVisit(visit_id, dt)
 
+            _LOG.info("--- Finished processing visit %s, time: %s", visit_id, loop_timer)
 
     def _filterDiaObjects(self, latest_objects, pointing_xyz, FOV_rad):
         """

--- a/bin/log2csv
+++ b/bin/log2csv
@@ -1,0 +1,158 @@
+#!/bin/env python
+
+"""
+Script to read ap_proto logs and produce CSV file.
+"""
+
+from __future__ import print_function
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+from argparse import ArgumentParser
+from collections import defaultdict
+import logging
+import sys
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+
+#---------------------
+# Local definitions --
+#---------------------
+
+def _configLogger(verbosity):
+    """ configure logging based on verbosity level """
+
+    levels = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    logfmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+    logging.basicConfig(level=levels.get(verbosity, logging.DEBUG), format=logfmt)
+
+# dictionary with visit statistics
+_values = defaultdict(lambda: "NULL")
+
+def _new_visit(line):
+    """
+    Initialize data structures for new visit.
+    """
+    _values.clear()
+    words = line.split()
+    visit = int(words[-4])
+    _values['visit'] = visit
+
+def _parse_counts(line):
+    """
+    Parse line with table row counts.
+    """
+    words = line.split()
+    count = int(words[-1])
+    if "DiaObject" in words:
+        _values['obj_count'] = count
+    elif "DiaSource" in words:
+        _values['src_count'] = count
+    elif "DiaForcedSource" in words:
+        _values['fsrc_count'] = count
+
+def _parse_timers(line):
+    """
+    Parse line with timer info.
+    """
+    words = line.replace('=', ' ').split()
+    real = float(words[-5])
+    cpu = float(words[-3]) + float(words[-1])
+    if " DiaObject select: " in line:
+        _values['obj_select_real'] = real
+        _values['obj_select_cpu'] = cpu
+    elif " DiaObject truncate: " in line:
+        _values['obj_trunc_real'] = real
+        _values['obj_trunc_cpu'] = cpu
+    elif " DiaObject insert: " in line:
+        _values['obj_insert_real'] = real
+        _values['obj_insert_cpu'] = cpu
+    elif " DiaSource insert: " in line:
+        _values['src_insert_real'] = real
+        _values['src_insert_cpu'] = cpu
+    elif " DiaForcedSource insert: " in line:
+        _values['fsrc_insert_real'] = real
+        _values['fsrc_insert_cpu'] = cpu
+    elif " L1-store: " in line:
+        _values['store_real'] = real
+        _values['store_cpu'] = cpu
+    elif " Finished processing visit " in line:
+        _values['visit_real'] = real
+        _values['visit_cpu'] = cpu
+
+def _parse_select_count(line):
+    """
+    Parse line with counter of selected rows
+    """
+    words = line.split()
+    count = int(words[-2])
+    if "database found" in line:
+        _values['obj_selected'] = count
+    elif "after filtering" in line:
+        _values['obj_in_fov'] = count
+
+# List of columns (keys in _values dictionary)
+_cols = ['visit',
+         'obj_select_real', 'obj_select_cpu', 'obj_trunc_real', 'obj_trunc_cpu',
+         'obj_insert_real', 'obj_insert_cpu', 'src_insert_real', 'src_insert_cpu',
+         'fsrc_insert_real', 'fsrc_insert_cpu', 'store_real', 'store_cpu',
+         'visit_real', 'visit_cpu', 'obj_selected', 'obj_in_fov',
+         'obj_count', 'src_count', 'fsrc_count']
+
+# Flag to print CSV header line once
+_header = True
+
+def _end_visit(line):
+    """
+    Dump collected information
+    """
+    global _header
+    if _header:
+        print(','.join(_cols))
+        _header = False
+    print(','.join(str(_values[c]) for c in _cols))
+
+# Map line sibstring to method
+_dispatch = [("Start processing visit", _new_visit),
+             (" row count: ", _parse_counts),
+             (": real=", _parse_timers),
+             ("ap_proto: database found ", _parse_select_count),
+             ("ap_proto: after filtering ", _parse_select_count),
+             ("Finished processing visit", _end_visit),            # must be last
+             ]
+
+#---------------------------------
+#  Application class definition --
+#---------------------------------
+
+def main():
+
+    descr = 'One-line application description.'
+    parser = ArgumentParser(description=descr)
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='More verbose output, can use several times.')
+    parser.add_argument('file', help='Name of input log file', nargs='+')
+    args = parser.parse_args()
+
+    # configure logging
+    _configLogger(args.verbose)
+
+    # open each file in order
+    for input in args.file:
+        for line in open(input):
+            for match, method in _dispatch:
+                # if line matches then call corresponding method
+                if match in line:
+                    method(line)
+
+
+#
+#  run application when imported as a main module
+#
+if __name__ == "__main__":
+    rc = main()
+    sys.exit(rc)

--- a/python/lsst/l1dbproto/generators.py
+++ b/python/lsst/l1dbproto/generators.py
@@ -7,6 +7,7 @@ Module defining methods for generating random things.
 #--------------------------------
 import math
 import numpy
+import logging
 
 #-----------------------------
 # Imports for other modules --
@@ -87,4 +88,4 @@ def rand_cone_xyz(direction, open_angle, n=1, seed=None):
 
     # rotate
     R = _rotation_matrix(numpy.array([0., 0., 1.]), direction)
-    return numpy.inner(res, R)
+    return numpy.inner(res, R).A

--- a/python/lsst/l1dbproto/timer.py
+++ b/python/lsst/l1dbproto/timer.py
@@ -45,7 +45,7 @@ class Timer(object):
     #----------------
     #  Constructor --
     #----------------
-    def __init__(self, name, doPrint=True):
+    def __init__(self, name="", doPrint=True):
         """
         @param name:  Time name, will be printed together with statistics
         @param doPrint: if True then print statistics on exist from context
@@ -72,6 +72,7 @@ class Timer(object):
         ru = resource.getrusage(resource.RUSAGE_SELF)
         self._startUser = ru.ru_utime
         self._startSys = ru.ru_stime
+        return self
 
     def stop(self):
         """
@@ -85,13 +86,16 @@ class Timer(object):
             self._startReal = None
             self._startUser = None
             self._startSys = None
+        return self
 
     def dump(self):
         """
         Dump timer statistics
         """
+        _LOG.info("%s", self)
+        return self
 
-        # If timer is running then add current statistics too
+    def __str__(self):
         real = self._sumReal
         user = self._sumUser
         sys = self._sumSys
@@ -100,7 +104,10 @@ class Timer(object):
             ru = resource.getrusage(resource.RUSAGE_SELF)
             user += ru.ru_utime - self._startUser
             sys += ru.ru_stime - self._startSys
-        _LOG.info("%s: real=%.3f user=%.3f sys=%.3f", self._name, real, user, sys)
+        info = "real=%.3f user=%.3f sys=%.3f" % (real, user, sys)
+        if self._name:
+            info = self._name + ": " + info
+        return info
 
     def __enter__(self):
         """


### PR DESCRIPTION
Replace sqlalchemy-generated queries with manually generated and
interpolated queries. This reduced CPU overhead for large INSERT queries.

Added more timers to the code. Added script to parse logs and generate
CVS files to analyze in pandas.