### PR TITLE
Re-implement L1db for afw.table catalogs.

### DIFF
--- a/bin/ap_proto
+++ b/bin/ap_proto
@@ -14,8 +14,6 @@ a database.
 from argparse import ArgumentParser
 from datetime import datetime, timedelta
 import logging
-import math
-import numpy
 import os
 import sys
 import time
@@ -23,6 +21,8 @@ import time
 #-----------------------------
 # Imports for other modules --
 #-----------------------------
+import numpy
+import lsst.afw.table as afwTable
 from lsst.l1dbproto import constants, DIA, generators, geom, l1db, timer
 from lsst.sphgeom import Angle, Circle, HtmPixelization, LonLat, UnitVector3d, Vector3d
 
@@ -81,6 +81,12 @@ def _visitTimes(start_time, interval_sec, count):
             count -= 1
         dt += delta
 
+# def _utc_seconds(dt):
+#     """Convert datetime to POSIX seconds
+#     """
+#     return int((dt - datetime.utcfromtimestamp(0)).total_seconds())
+
+
 # special code to makr sources ouside reagion
 _OUTSIDER = -666
 
@@ -93,6 +99,8 @@ _TRANSIENT_START_ID = 1000000000
 
 
 class APProto(object):
+    """Implementation of Alert Production prototype.
+    """
 
     def __init__(self):
 
@@ -131,6 +139,8 @@ class APProto(object):
         _configLogger(self.args.verbose)
 
     def run(self):
+        """Run whole shebang.
+        """
 
         # instantiate db interface
         db = l1db.L1db(self.args.config)
@@ -159,7 +169,7 @@ class APProto(object):
         if last_visit is not None and last_visit.lastObjectId is not None:
             self.lastObjectId = max(self.lastObjectId, last_visit.lastObjectId)
         if self.lastObjectId < len(var_sources):
-            _LOG.error('next object id is too low: %s', nextObjectId)
+            _LOG.error('next object id is too low: %s', self.lastObjectId)
             return 1
         _LOG.debug("lastObjectId: %s", self.lastObjectId)
 
@@ -248,11 +258,11 @@ class APProto(object):
                         try:
                             pid, status = os.waitpid(pid, 0)
                             if status != 0:
-                                _LOG.warn(COLOR_RED + "Child process PID=%s failed: %s" +
-                                          COLOR_RESET, pid, status)
+                                _LOG.warning(COLOR_RED + "Child process PID=%s failed: %s" +
+                                             COLOR_RESET, pid, status)
                         except OSError as exc:
-                            _LOG.warn(COLOR_RED + "wait failed for PID=%s: %s" +
-                                      COLOR_RESET, pid, exc)
+                            _LOG.warning(COLOR_RED + "wait failed for PID=%s: %s" +
+                                         COLOR_RESET, pid, exc)
 
                 else:
 
@@ -266,6 +276,8 @@ class APProto(object):
             _LOG.info(COLOR_BLUE + "--- Finished processing visit %s, time: %s" +
                       COLOR_RESET, visit_id, loop_timer)
 
+        return 0
+
     def visit(self, db, visit_id, dt, region, sources, indices, tile=None):
         """AP processing of a single visit (with known sources)
 
@@ -275,11 +287,13 @@ class APProto(object):
         dt : `datetime`
             Time of visit
         region : `sphgem.Region`
-            Region, could be thw whole FOV (Circle) or small piece of it
+            Region, could be the whole FOV (Circle) or small piece of it
         sources : `numpy.array`
-            Array of xyz coordinates of sources, this hass all visit sources,
+            Array of xyz coordinates of sources, this has all visit sources,
             not only current tile
         indices : `numpy.array`
+            array of indices of sources, 1-dim ndarray, transient sources
+            have negative indices
         tile : `tuple`
         """
 
@@ -323,7 +337,7 @@ class APProto(object):
             read_srcs = db.getDiaSources(region, latest_objects, explain=self.args.explain)
             _LOG.info(name+'database found %s sources', len(read_srcs))
 
-            read_srcs = db.getDiaFSources(latest_objects, explain=self.args.explain)
+            read_srcs = db.getDiaForcedSources(latest_objects, explain=self.args.explain)
             _LOG.info(name+'database found %s forced sources', len(read_srcs))
 
         if not self.args.no_update:
@@ -346,28 +360,75 @@ class APProto(object):
                     db.storeDiaForcedSources(fsrcs, explain=self.args.explain)
 
     def _filterDiaObjects(self, latest_objects, region):
-        """
-        Filter out objects from a list which are outside region.
-        """
-        res = []
-        for obj in latest_objects:
-            lonLat = LonLat.fromDegrees(float(obj.ra), float(obj.decl))
-            dir_obj = UnitVector3d(lonLat)
-            if region.contains(dir_obj):
-                res.append(obj)
+        """Filter out objects from a catalog which are outside region.
 
-        return res
+        Parameters
+        ----------
+        latest_objects : `afw.table.BaseCatalog`
+            Catalog containing DiaObject records
+        region : `sphgem.Region`
+
+        Returns
+        -------
+        Filtered `afw.table.BaseCatalog` containing only records contained
+        in the region.
+        """
+        mask = numpy.ndarray(len(latest_objects), dtype=bool)
+        for i, obj in enumerate(latest_objects):
+            # TODO: For now we use L1DB units (degrees), will have to be changed
+            # in case we adopt afw units.
+            lonLat = LonLat.fromDegrees(float(obj['coord_ra']), float(obj['coord_dec']))
+            dir_obj = UnitVector3d(lonLat)
+            mask[i] = region.contains(dir_obj)
+
+        return latest_objects.subset(mask)
+
+    def _makeDiaObjectSchema(self):
+        """Make afw.table schema for DiaObjects.
+
+        Schema should be compatible with L1DB schema and it should contain
+        all fields that have no default values in the schema.
+        """
+        schema = afwTable.Schema()
+        schema.addField("id", "L", doc="unique ID")
+        # TODO: in regular afw.table this should be "Angle" with units="rad",
+        # but l1db does not know about all conversions yet
+        schema.addField("coord_ra", "D", doc="position in ra/dec", units="deg")
+        schema.addField("coord_dec", "D", doc="position in ra/dec", units="deg")
+
+        # L1DB-specific stuff, current implementation knows how to fill
+        # time-related columns
+        # schema.addField("validityStart", "L")
+        # schema.addField("validityEnd", "L")
+        # schema.addField("lastNonForcedSource", "L")
+        schema.addField("htmId20", "L", doc="HTM index")
+
+        return schema
 
     def _makeDiaObjects(self, sources, indices, dt):
-        """
-        Over-simplified implementation of source-to-object matching and
+        """Over-simplified implementation of source-to-object matching and
         new DiaObject generation.
 
         Currently matching is based on info passed along by source
         generator and does not even use DiaObjects from database.
+
+        Parameters
+        ----------
+        sources : `numpy.array`
+            (x, y, z) coordinates of sources, array dimension is (N, 3)
+        indices : `numpy.array`
+            array of indices of sources, 1-dim ndarray, transient sources
+            have negative indices
+        dt : `datetime.datetime`
+            Visit time.
+
+        Returns
+        -------
+        `afw.table.BaseCatalog`
         """
 
-        objects = []
+        schema = self._makeDiaObjectSchema()
+        catalog = afwTable.BaseCatalog(schema)
         n_trans = 0
         for i in range(len(sources)):
 
@@ -385,55 +446,97 @@ class APProto(object):
             dir_v = UnitVector3d(v3d)
             pixelator = HtmPixelization(constants.HTM_LEVEL)
             index = pixelator.index(dir_v)
-            obj = l1db.DiaObject(diaObjectId=var_idx, validityStart=dt, validityEnd=None,
-                                 lastNonForcedSource=dt,
-                                 ra=ra, decl=decl, raSigma=0., declSigma=0., ra_decl_Cov=0.,
-                                 radecTai=0., pmRa=0., pmRaSigma=0., pmDecl=0., pmDeclSigma=0.,
-                                 pmRa_pmDecl_Cov=0., parallax=0., parallaxSigma=0.,
-                                 pmRa_parallax_Cov=0., pmDecl_parallax_Cov=0.,
-                                 pmParallaxLnL=0., pmParallaxChi2=0., pmParallaxNdata=0,
-                                 flags=0, htmId20=index)
-            objects += [obj]
-        _LOG.info('found %s matching objects and %s transients/noise', len(objects) - n_trans, n_trans)
 
-        return objects
+            record = catalog.addNew()
+            record.set("id", var_idx)
+            # record.set("validityStart", _utc_seconds(dt))
+            # record.set("validityEnd", 0)
+            # record.set("lastNonForcedSource", _utc_seconds(dt))
+            record.set("coord_ra", ra)
+            record.set("coord_dec", decl)
+            record.set("htmId20", index)
+
+        _LOG.info('found %s matching objects and %s transients/noise', len(catalog) - n_trans, n_trans)
+
+        return catalog
 
     def _forcedPhotometry(self, objects, latest_objects, dt):
-        """
-        Do forced photometry on latest_objects which are not in objects.
+        """Do forced photometry on latest_objects which are not in objects.
 
-        Extends objects list with new DiaObjects.
+        Extends objects catalog with new DiaObjects.
+
+        Parameters
+        ----------
+        objects : `afw.table.BaseCatalog`
+            Catalog containing DiaObject records
+        latest_objects : `afw.table.BaseCatalog`
+            Catalog containing DiaObject records
         """
 
         # Ids of the detected objects
-        ids = set(obj.diaObjectId for obj in objects)
+        ids = set(obj['id'] for obj in objects)
 
         for obj in latest_objects:
             # only do it for 30 days after last detection
-            if obj.diaObjectId in ids:
+            if obj['id'] in ids:
                 continue
-            delta = dt - obj.lastNonForcedSource
+            lastNonForcedSource = datetime.utcfromtimestamp(obj['lastNonForcedSource'])
+            delta = dt - lastNonForcedSource
             if delta > timedelta(days=30):
                 continue
 
-            # make new object with the same ID
-            new_obj = l1db.DiaObject(diaObjectId=obj.diaObjectId, validityStart=dt, validityEnd=None,
-                                     lastNonForcedSource=obj.lastNonForcedSource,
-                                     ra=float(obj.ra), decl=float(obj.decl),
-                                     raSigma=0., declSigma=0., ra_decl_Cov=0.,
-                                     radecTai=0., pmRa=0., pmRaSigma=0., pmDecl=0., pmDeclSigma=0.,
-                                     pmRa_pmDecl_Cov=0., parallax=0., parallaxSigma=0.,
-                                     pmRa_parallax_Cov=0., pmDecl_parallax_Cov=0.,
-                                     pmParallaxLnL=0., pmParallaxChi2=0., pmParallaxNdata=0,
-                                     flags=0, htmId20=obj.htmId20)
-            objects.append(new_obj)
+            record = objects.addNew()
+            record.set("id", obj['id'])
+            # record.set("validityStart", _utc_seconds(dt))
+            # record.set("validityEnd", 0)
+            # record.set("lastNonForcedSource", obj['lastNonForcedSource'])
+            record.set("coord_ra", obj["coord_ra"])
+            record.set("coord_dec", obj["coord_dec"])
+            record.set("htmId20", obj["htmId20"])
+
+    def _makeDiaSourceSchema(self):
+        """Make afw.table schema for DiaSource.
+
+        Schema should be compatible with L1DB schema and it should contain
+        all fields that have no default values in the schema.
+        """
+        schema = afwTable.Schema()
+        schema.addField("id", "L", doc="unique ID")
+        # TODO: in regular afw.table this should be "Angle" with units="rad",
+        # but l1db does not know about all conversions yet
+        schema.addField("coord_ra", "D", doc="position in ra/dec", units="deg")
+        schema.addField("coord_dec", "D", doc="position in ra/dec", units="deg")
+
+        # L1DB-specific stuff
+        schema.addField("diaObjectId", "L")
+        schema.addField("ssObjectId", "L")
+        schema.addField("ccdVisitId", "L")
+        schema.addField("parent", "L")
+        schema.addField("flags", "L")
+        schema.addField("htmId20", "L", doc="HTM index")
+
+        return schema
 
     def _makeDiaSources(self, sources, indices, visit_id):
-        """
-        Generate set of DiaSources to store in a database
+        """Generate catalog of DiaSources to store in a database
+
+        Parameters
+        ----------
+        sources : `numpy.ndarray`
+            (x, y, z) coordinates of sources, array dimension is (N, 3)
+        indices : `numpy.array`
+            array of indices of sources, 1-dim ndarray, transient sources
+            have negative indices
+        visit_id : `int`
+            ID of the visit
+
+        Returns
+        -------
+        `afw.table.BaseCatalog`
         """
 
-        srcs = []
+        schema = self._makeDiaSourceSchema()
+        catalog = afwTable.BaseCatalog(schema)
         for i in range(len(sources)):
 
             var_idx = int(indices[i])
@@ -449,32 +552,60 @@ class APProto(object):
             index = pixelator.index(dir_v)
 
             self.lastSourceId += 1
-            src = l1db.DiaSource(diaSourceId=self.lastSourceId, ccdVisitId=visit_id,
-                                 diaObjectId=var_idx,
-                                 prv_procOrder=0, midPointTai=0.,
-                                 ra=ra, decl=decl, raSigma=0., declSigma=0., ra_decl_Cov=0.,
-                                 x=0., xSigma=0., y=0., ySigma=0., x_y_Cov=0.,
-                                 apFlux=0., apFluxErr=0., snr=5.,
-                                 flags=0, htmId20=index)
-            srcs += [src]
 
-        return srcs
+            record = catalog.addNew()
+            record.set("id", self.lastSourceId)
+            record.set("ccdVisitId", visit_id)
+            record.set("diaObjectId", var_idx)
+            record.set("parent", 0)
+            record.set("coord_ra", ra)
+            record.set("coord_dec", decl)
+            record.set("flags", 0)
+            record.set("htmId20", index)
+
+        return catalog
+
+    def _makeDiaForcedSourceSchema(self):
+        """Make afw.table schema for DiaForcedSource.
+
+        Schema should be compatible with L1DB schema and it should contain
+        all fields that have no default values in the schema.
+        """
+        schema = afwTable.Schema()
+
+        # L1DB-specific stuff
+        schema.addField("diaObjectId", "L")
+        schema.addField("ccdVisitId", "L")
+        schema.addField("flags", "L")
+
+        return schema
 
     def _makeDiaForcedSources(self, objects, visit_id):
-        """
-        Generate set of DiaForcedSources to store in a database
+        """Generate catalog of DiaForcedSources to store in a database.
+
+        Parameters
+        ----------
+        objects : `afw.table.BaseCatalog`
+            Catalog containing DiaObject records
+        visit_id : `int`
+            ID of the visit
+
+        Returns
+        -------
+        `afw.table.BaseCatalog`
         """
 
-        fsrcs = []
+        schema = self._makeDiaForcedSourceSchema()
+        catalog = afwTable.BaseCatalog(schema)
         for obj in objects:
 
-            src = l1db.DiaForcedSource(diaObjectId=obj.diaObjectId, ccdVisitId=visit_id,
-                                       psFlux=0., psFluxSigma=0.,
-                                       x=0., y=0.,
-                                       flags=0)
-            fsrcs += [src]
+            record = catalog.addNew()
+            record.set("diaObjectId", obj['id'])
+            record.set("ccdVisitId", visit_id)
+            record.set("flags", 0)
 
-        return fsrcs
+        return catalog
+
 
 #
 #  run application when imported as a main module

--- a/bin/create_l1_schema
+++ b/bin/create_l1_schema
@@ -16,6 +16,7 @@ import sys
 #-----------------------------
 # Imports for other modules --
 #-----------------------------
+import lsst.afw.table as afwTable
 from lsst.l1dbproto import l1db
 
 #---------------------
@@ -32,6 +33,43 @@ def _configLogger(verbosity):
     logging.basicConfig(level=levels.get(verbosity, logging.DEBUG), format=logfmt)
 
 
+#
+# Copied from ap_association/dia_object.py
+#
+def make_minimal_dia_object_schema():
+    """ Define and create the minimal schema required for a DIAObject.
+
+    Return
+    ------
+    lsst.afw.table.schema.schema.Schema
+    """
+
+    schema = afwTable.SourceTable.makeMinimalSchema()
+    # For the MVP/S we currently only care about the position though
+    # in the future we will add summary computations for fluxes etc.
+    # as well as their errors.
+
+    # In the future we would like to store a covariance of the coordinate.
+    # This functionality is not defined in currently in the stack, so we will
+    # hold off until it is implemented. This is to be addressed in DM-7101.
+    schema.addField("indexer_id", type="L")
+    schema.addField("n_dia_sources", type="L")
+
+    return schema
+
+
+def make_minimal_dia_source_schema():
+    """ Define and create the minimal schema required for a DIASource.
+
+    Return
+    ------
+    lsst.afw.table.schema.schema.Schema
+    """
+
+    schema = afwTable.SourceTable.makeMinimalSchema()
+
+    return schema
+
 #---------------------------------
 #  Application class definition --
 #---------------------------------
@@ -47,6 +85,9 @@ def main():
                         'all data in the tables, use with extreme caution')
     parser.add_argument('-c', '--config', default="l1db.cfg",
                         help='Name of the config file, def: l1db.cfg')
+    parser.add_argument('-a', '--association', default=False,
+                        action='store_true',
+                        help='Use afw.table schema from ap_association')
     args = parser.parse_args()
 
     # configure logging
@@ -55,8 +96,13 @@ def main():
     # instantiate db interface
     db = l1db.L1db(args.config)
 
+    schema_dict = None
+    if args.association:
+        schema_dict = dict(DiaObject=make_minimal_dia_object_schema(),
+                           DiaSource=make_minimal_dia_source_schema())
+
     # do it
-    db.makeSchema(args.drop)
+    db.makeSchema(schema_dict=schema_dict, drop=args.drop)
 
 
 #

--- a/bin/create_l1_schema
+++ b/bin/create_l1_schema
@@ -93,16 +93,16 @@ def main():
     # configure logging
     _configLogger(args.verbose)
 
-    # instantiate db interface
-    db = l1db.L1db(args.config)
-
-    schema_dict = None
+    afw_schemas = None
     if args.association:
-        schema_dict = dict(DiaObject=make_minimal_dia_object_schema(),
+        afw_schemas = dict(DiaObject=make_minimal_dia_object_schema(),
                            DiaSource=make_minimal_dia_source_schema())
 
+    # instantiate db interface
+    db = l1db.L1db(config=args.config, afw_schemas=afw_schemas)
+
     # do it
-    db.makeSchema(schema_dict=schema_dict, drop=args.drop)
+    db.makeSchema(drop=args.drop)
 
 
 #

--- a/bin/parse_cat
+++ b/bin/parse_cat
@@ -11,11 +11,14 @@ from __future__ import print_function
 #  Imports of standard modules --
 #--------------------------------
 from argparse import ArgumentParser
+import re
+import os
 import sys
 
 #-----------------------------
 # Imports for other modules --
 #-----------------------------
+import yaml
 
 #---------------------
 # Local definitions --
@@ -25,8 +28,9 @@ import sys
 STATE_TOP = 0
 STATE_TABLE = 1
 STATE_TABLE_SKIP = 2
+STATE_DESCR = 3
 
-# Tables that we need
+# Tables that we need for L1DB
 TABLES = ['DiaObject', 'SSObject', 'DiaSource', 'DiaForcedSource', 'DiaObject_To_Object_Match']
 
 #---------------------------------
@@ -36,72 +40,242 @@ TABLES = ['DiaObject', 'SSObject', 'DiaSource', 'DiaForcedSource', 'DiaObject_To
 
 def main():
 
-    descr = 'Read and parse schema in cat package.'
+    descr = 'Read and parse L1 schema in cat package.'
     parser = ArgumentParser(description=descr)
+    parser.add_argument('-a', '--all', default=False, action="store_true",
+                        help='Generate schema for all tables')
+    parser.add_argument('-y', '--yaml', default=False, action="store_true",
+                        help='Generate YAML schema file')
     parser.add_argument('file', help='Name of input file')
     args = parser.parse_args()
 
     state = STATE_TOP
-    table = None
-    columns = []
+    tables = []
+    table = {}
     for line in open(args.file):
         line = line.strip()
-
-        if line.startswith("--"):
-            # skip all comments
-            continue
 
         if state == STATE_TOP:
             # look for CREATE TABLE
             if line.startswith("CREATE TABLE"):
-                table = line.split()[2]
-                if table in TABLES:
-                    columns = []
+                name = line.split()[2]
+                if args.all or name in TABLES:
+                    table = dict(table=name)
                     state = STATE_TABLE
                 else:
                     state = STATE_TABLE_SKIP
-        elif state == STATE_TABLE_SKIP:
-            # look for closing paren
+                continue
+
+        if state == STATE_TABLE_SKIP:
+            # look for closing paren, ignore anything else
             if line.startswith(')'):
                 state = STATE_TOP
-        elif state == STATE_TABLE:
-            if line.startswith(')'):
-                state = STATE_TOP
-                dumpTable(table, columns)
-            elif line.startswith('('):
-                pass
-            elif line.startswith('PRIMARY') or line.startswith('INDEX'):
-                # don't care about index definition
-                pass
+            continue
+
+        if state == STATE_DESCR:
+            # parsing multi-line <descr> tag in comments
+            if line.startswith("--"):
+                state = parse_comment(line, table, state)
+                continue
             else:
-                # column definition
-                line = line.rstrip(',')
-                words = line.split()
-                column = words[0]
-                col_type = words[1]
-                nullable = "NOT NULL" not in line
-                try:
-                    idx = words.index('DEFAULT')
-                    default = words[idx + 1]
-                except ValueError:
-                    default = None
-                columns.append((column, col_type, nullable, default))
+                # expecting a comment, but got something else,
+                # get back to table parsing in next 'if'
+                state = STATE_TABLE
 
-def dumpTable(table, columns):
+        if state == STATE_TABLE:
+            if line.startswith(')'):
+                # end of table definition
+                tables.append(table)
+                table = {}
+                state = STATE_TOP
+            elif line.startswith('('):
+                # start of columns definitions
+                pass
+            elif line.startswith("--"):
+                # comments, get metadata from it
+                state = parse_comment(line, table, state)
+            else:
+                # either column or index definition
+                index = parse_index(line)
+                if index:
+                    table.setdefault('indices', []).append(index)
+                else:
+                    column = parse_column(line)
+                    if column:
+                        table.setdefault('columns', []).append(column)
+            continue
 
-    print("\ntable = Table('{}', self._metadata,".format(table))
-    for column, col_type, nullable, default in columns:
-        args = [repr(column), col_type, 'nullable=' + str(nullable)]
+    # done with parsing, dump everything
+    if args.yaml:
+        dump_yaml(tables, args)
+    else:
+        for table in tables:
+            dump_pytables(table)
+
+
+def parse_comment(line, table, state):
+    """Extract meta information from comment line.
+
+    Parameters
+    ----------
+    line : str
+        Line with comment, usually starts with '--' string
+    table : `dict`
+        Table definition for current table.
+    state : `int`
+        Current parser state.
+
+    Returns
+    -------
+    New parser state.
+    """
+    # update either table itself or last column
+    to_update = table
+    if 'columns' in table:
+        to_update = table['columns'][-1]
+
+    line = line.lstrip('-')
+    if state == STATE_DESCR:
+        # continue parsing <descr> tag
+        idx = line.find("</descr>")
+        if idx >= 0:
+            # closing tag is here
+            state = STATE_TABLE
+            line = line[:idx]
+        line = line.strip()
+        if line:
+            to_update['description'] += ' ' + line
+    else:
+        # order is important here
+        tests = [r"<descr>(?P<description>.*)</descr>",
+                 r"<descr>(?P<description>.*)",
+                 r"<unit>(?P<unit>.*)</unit>",
+                 r"<ucd>(?P<ucd>.*)</ucd>"]
+        for test in tests:
+            match = re.search(test, line)
+            if match:
+                to_update.update(match.groupdict())
+                if "<descr>" in test and "</descr>" not in test:
+                    # continues on next line
+                    state = STATE_DESCR
+                break
+    return state
+
+
+def parse_column(line):
+    """Try to parse column definition.
+
+    Parameters
+    ----------
+    line : str
+        Line with column definition.
+
+    Returns
+    -------
+    None if line is not a column definition, otherwise returns a dict with
+    column description.
+    """
+    line = line.rstrip(',')
+    words = line.split()
+    if len(words) < 2:
+        return None
+    column = words[0]
+    col_type = words[1]
+    nullable = "NOT NULL" not in line
+    column = dict(name=column, type=col_type, nullable=nullable)
+    try:
+        idx = words.index('DEFAULT')
+        column['default'] = words[idx + 1]
+    except ValueError:
+        pass
+    return column
+
+
+def parse_index(line):
+    """Try to parse line as an index definition
+
+    Returns None if it is not an index definition, otherwise returns dict.
+    """
+    pkey_re = re.compile(r"\s*PRIMARY\s+KEY\s+((?P<name>\w+)\s+)?\((?P<columns>.*)\).*")
+    unique_re = re.compile(r"\s*UNIQUE\s+(KEY\s+|INDEX\s+)?((?P<name>\w+)\s+)?\((?P<columns>.*)\).*")
+    index_re = re.compile(r"\s*((KEY|INDEX)\s+)((?P<name>\w+)\s+)?\((?P<columns>.*)\).*")
+
+    tests = dict(PRIMARY=pkey_re,
+                 UNIQUE=unique_re,
+                 INDEX=index_re)
+    index = None
+    for idx_type, test in tests.items():
+        match = test.match(line)
+        if match:
+            index = match.groupdict()
+            index['type'] = idx_type
+            break
+
+    if index:
+        columns = index['columns'].split(',')
+        index['columns'] = [c.strip() for c in columns]
+
+    return index
+
+
+def dump_pytables(table):
+    """Dump table definition as a Python code for SQLAlchemy.
+
+    Parameters
+    ----------
+    table : `dict`
+        Table definition.
+    """
+
+    print("\ntable = Table('{}', self._metadata,".format(table['table']))
+    for column in table['columns']:
+        name = column['name']
+        col_type = column['type']
+        nullable = column['nullable']
+        default = column.get('default')
+        args = [repr(name), col_type, 'nullable=' + str(nullable)]
         if default is not None:
             args += ['default=' + default]
         print("              Column({0}),".format(', '.join(args)))
     print("              )")
 
     # also dump full list of all non-nullable column names
-    print("-- all columns for table {0}".format(table))
-    print(' '.join(c[0] for c in columns))
-    print("-- non-nullable columns for table {0}".format(table))
-    print(' '.join(c[0] for c in columns if not c[2]))
+    print("-- all columns for table {0}".format(table['table']))
+    print(' '.join(c['name'] for c in table['columns']))
+    print("-- non-nullable columns for table {0}".format(table['table']))
+    print(' '.join(c['name'] for c in table['columns'] if not c['nullable']))
+
+
+def dump_yaml(tables, args):
+    """Dump list of tables in YAML format.
+
+    Parameters
+    ----------
+    tables : `list` of `dict`
+        List of table definitions
+    args : `Namespace`
+        Command line arguments
+    """
+
+    # this is to output dict keys in the same order they were added to the dicts
+    # (assuming Python3 ordered dicts):
+    # https://stackoverflow.com/questions/16782112/can-pyyaml-dump-dict-items-in-non-alphabetical-order
+    yaml.add_representer(dict, represent_ordereddict)
+
+    print("# Generated from {}".format(os.path.abspath(args.file)))
+    print("# by {} script".format(sys.argv[0]))
+    yaml.dump_all(tables, stream=sys.stdout, default_flow_style=False)
+
+
+def represent_ordereddict(dumper, data):
+    value = []
+    for item_key, item_value in data.items():
+        node_key = dumper.represent_data(item_key)
+        node_value = dumper.represent_data(item_value)
+
+        value.append((node_key, node_value))
+
+    return yaml.nodes.MappingNode(u'tag:yaml.org,2002:map', value)
 
 
 #

--- a/data/l1db-afw-map.yaml
+++ b/data/l1db-afw-map.yaml
@@ -8,5 +8,6 @@ DiaObject:
   decl: coord_dec
 DiaSource:
   diaSourceId: id
+  parentDiaSourceId: parent
   ra: coord_ra
   decl: coord_dec

--- a/data/l1db-afw-map.yaml
+++ b/data/l1db-afw-map.yaml
@@ -1,0 +1,12 @@
+# This file defines mapping between L1DB column names and afw.table column
+# names. Top-level structure is a dictionary indexed by table name and the
+# values are dictionaries where key is the name of column in L1DB and value
+# is the name of the column in afw.table
+DiaObject:
+  diaObjectId: id
+  ra: coord_ra
+  decl: coord_dec
+DiaSource:
+  diaSourceId: id
+  ra: coord_ra
+  decl: coord_dec

--- a/data/l1db-schema-extra.yaml
+++ b/data/l1db-schema-extra.yaml
@@ -1,0 +1,14 @@
+# Extra columns for L1DB schema that do not appear in cat schema but
+# are necessary for implementation purposes. Definitions in this file
+# override column definition in standard schema.
+table: DiaObject
+columns:
+- name: lastNonForcedSource
+  type: DATETIME
+  nullable: false
+  description: Last time when non-forced DIASource was seen for this object.
+- name: validityEnd
+  type: DATETIME
+  nullable: true
+  description: Time when validity of this diaObject ends.
+  default: null

--- a/data/l1db-schema-extra.yaml
+++ b/data/l1db-schema-extra.yaml
@@ -1,6 +1,8 @@
 # Extra columns for L1DB schema that do not appear in cat schema but
 # are necessary for implementation purposes. Definitions in this file
 # override column definition in standard schema.
+# Special indices for DiaObject table re defined as special tables here
+# but have no columns.
 table: DiaObject
 columns:
 - name: lastNonForcedSource
@@ -12,3 +14,28 @@ columns:
   nullable: true
   description: Time when validity of this diaObject ends.
   default: null
+---
+table: DiaObjectLast
+indices:
+- name: PK_DiaObjectLast
+  columns:
+  - htmId20
+  - diaObjectId
+  type: PRIMARY
+- name: IDX_DiaObjectLast_diaObjectId
+  columns:
+  - diaObjectId
+  type: INDEX
+---
+table: DiaObjectIndexHtmFirst
+indices:
+- name: PK_DiaObject
+  columns:
+  - htmId20
+  - diaObjectId
+  - validityStart
+  type: PRIMARY
+- name: IDX_DiaObject_diaObjectId
+  columns:
+  - diaObjectId
+  type: INDEX

--- a/data/l1db-schema.yaml
+++ b/data/l1db-schema.yaml
@@ -1,0 +1,1664 @@
+# Generated from /home/salnikov/cat/sql/baselineSchema.sql
+# by ./bin/parse_cat script
+table: DiaObject
+description: The DiaObject table contains descriptions of the astronomical objects
+  detected on one or more difference images.
+columns:
+- name: diaObjectId
+  type: BIGINT
+  nullable: false
+  description: Unique id.
+  ucd: meta.id;src
+- name: validityStart
+  type: DATETIME
+  nullable: false
+  description: Time when validity of this diaObject starts.
+- name: validityEnd
+  type: DATETIME
+  nullable: false
+  description: Time when validity of this diaObject ends.
+- name: ra
+  type: DOUBLE
+  nullable: false
+  description: RA-coordinate of the position of the object at time radecTai.
+  ucd: pos.eq.ra
+  unit: deg
+- name: raSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of ra.
+  ucd: stat.error;pos.eq.ra
+  unit: deg
+- name: decl
+  type: DOUBLE
+  nullable: false
+  description: Decl-coordinate of the position of the object at time radecTai.
+  ucd: pos.eq.dec
+  unit: deg
+- name: declSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of decl.
+  ucd: stat.error;pos.eq.dec
+  unit: deg
+- name: ra_decl_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance between ra and decl.
+  unit: deg^2
+- name: radecTai
+  type: DOUBLE
+  nullable: false
+  description: Time at which the object was at a position ra/decl.
+  ucd: time.epoch
+- name: pmRa
+  type: FLOAT
+  nullable: false
+  description: Proper motion (ra).
+  ucd: pos.pm
+  unit: mas/yr
+- name: pmRaSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of pmRa.
+  ucd: stat.error;pos.pm
+  unit: mas/yr
+- name: pmDecl
+  type: FLOAT
+  nullable: false
+  description: Proper motion (decl).
+  ucd: pos.pm
+  unit: mas/yr
+- name: pmDeclSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of pmDecl.
+  ucd: stat.error;pos.pm
+  unit: mas/yr
+- name: parallax
+  type: FLOAT
+  nullable: false
+  description: Parallax.
+  ucd: pos.parallax
+  unit: mas
+- name: parallaxSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of parallax.
+  ucd: stat.error;pos.parallax
+  unit: mas
+- name: pmRa_pmDecl_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance of pmRa and pmDecl.
+  ucd: stat.covariance;pos.eq
+  unit: (mas/yr)^2
+- name: pmRa_parallax_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance of pmRa and parallax.
+  ucd: stat.covariance
+  unit: mas^2/yr
+- name: pmDecl_parallax_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance of pmDecl and parallax.
+  ucd: stat.covariance
+  unit: mas^2/yr
+- name: pmParallaxLnL
+  type: FLOAT
+  nullable: false
+  description: Natural log of the likelihood of the linear proper motion parallax
+    fit.
+  ucd: stat.likelihood
+- name: pmParallaxChi2
+  type: FLOAT
+  nullable: false
+  description: Chi^2 static of the model fit.
+  ucd: stat.fit.chi2
+- name: pmParallaxNdata
+  type: INT
+  nullable: false
+  description: The number of data points used to fit the model.
+- name: uPSFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean point-source model magnitude for u filter.
+  ucd: phot.count
+  unit: nmgy
+- name: uPSFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of uPSFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: uPSFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of uPSFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: uPSFluxChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic for the scatter of uPSFlux around uPSFluxMean.
+  ucd: stat.fit.chi2
+- name: uPSFluxNdata
+  type: INT
+  nullable: true
+  description: The number of data points used to compute uPSFluxChi2.
+- name: uFPFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean forced photometry flux for u filter.
+  ucd: phot.count
+  unit: nmgy
+- name: uFPFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of uFPFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: uFPFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of uFPFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: gPSFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean point-source model magnitude for g filter.
+  ucd: phot.count
+  unit: nmgy
+- name: gPSFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of gPSFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: gPSFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of gPSFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: gPSFluxChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic for the scatter of gPSFlux around gPSFluxMean.
+  ucd: stat.fit.chi2
+- name: gPSFluxNdata
+  type: INT
+  nullable: true
+  description: The number of data points used to compute gPSFluxChi2.
+- name: gFPFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean forced photometry flux for g filter.
+  ucd: phot.count
+  unit: nmgy
+- name: gFPFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of gFPFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: gFPFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of gFPFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: rPSFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean point-source model magnitude for r filter.
+  ucd: phot.count
+  unit: nmgy
+- name: rPSFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of rPSFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: rPSFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of rPSFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: rPSFluxChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic for the scatter of rPSFlux around rPSFluxMean.
+  ucd: stat.fit.chi2
+- name: rPSFluxNdata
+  type: INT
+  nullable: true
+  description: The number of data points used to compute rPSFluxChi2.
+- name: rFPFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean forced photometry flux for r filter.
+  ucd: phot.count
+  unit: nmgy
+- name: rFPFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of rFPFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: rFPFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of rFPFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: iPSFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean point-source model magnitude for i filter.
+  ucd: phot.count
+  unit: nmgy
+- name: iPSFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of iPSFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: iPSFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of iPSFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: iPSFluxChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic for the scatter of iPSFlux around iPSFluxMean.
+  ucd: stat.fit.chi2
+- name: iPSFluxNdata
+  type: INT
+  nullable: true
+  description: The number of data points used to compute iPSFluxChi2.
+- name: iFPFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean forced photometry flux for i filter.
+  ucd: phot.count
+  unit: nmgy
+- name: iFPFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of iFPFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: iFPFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of iFPFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: zPSFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean point-source model magnitude for z filter.
+  ucd: phot.count
+  unit: nmgy
+- name: zPSFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of zPSFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: zPSFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of zPSFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: zPSFluxChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic for the scatter of zPSFlux around zPSFluxMean.
+  ucd: stat.fit.chi2
+- name: zPSFluxNdata
+  type: INT
+  nullable: true
+  description: The number of data points used to compute zPSFluxChi2.
+- name: zFPFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean forced photometry flux for z filter.
+  ucd: phot.count
+  unit: nmgy
+- name: zFPFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of zFPFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: zFPFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of zFPFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: yPSFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean point-source model magnitude for y filter.
+  ucd: phot.count
+  unit: nmgy
+- name: yPSFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of yPSFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: yPSFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of yPSFlux.
+  ucd: stat.error
+  unit: nmgy
+- name: yPSFluxChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic for the scatter of yPSFlux around yPSFluxMean.
+  ucd: stat.fit.chi2
+- name: yPSFluxNdata
+  type: INT
+  nullable: true
+  description: The number of data points used to compute yPSFluxChi2.
+- name: yFPFluxMean
+  type: FLOAT
+  nullable: true
+  description: Weighted mean forced photometry flux for y filter.
+  ucd: phot.count
+  unit: nmgy
+- name: yFPFluxMeanErr
+  type: FLOAT
+  nullable: true
+  description: Standard error of yFPFluxMean.
+  ucd: stat.error
+  unit: nmgy
+- name: yFPFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Standard deviation of the distribution of yFPFlux.
+  ucd: stat.stdev
+  unit: nmgy
+- name: uLcPeriodic
+  type: BLOB
+  nullable: true
+  description: Periodic features extracted from light-curves using generalized Lomb-Scargle
+    periodogram for u filter. [32 FLOAT].
+- name: gLcPeriodic
+  type: BLOB
+  nullable: true
+  description: Periodic features extracted from light-curves using generalized Lomb-Scargle
+    periodogram for g filter. [32 FLOAT].
+- name: rLcPeriodic
+  type: BLOB
+  nullable: true
+  description: Periodic features extracted from light-curves using generalized Lomb-Scargle
+    periodogram for r filter. [32 FLOAT].
+- name: iLcPeriodic
+  type: BLOB
+  nullable: true
+  description: Periodic features extracted from light-curves using generalized Lomb-Scargle
+    periodogram for i filter. [32 FLOAT].
+- name: zLcPeriodic
+  type: BLOB
+  nullable: true
+  description: Periodic features extracted from light-curves using generalized Lomb-Scargle
+    periodogram for z filter. [32 FLOAT].
+- name: yLcPeriodic
+  type: BLOB
+  nullable: true
+  description: Periodic features extracted from light-curves using generalized Lomb-Scargle
+    periodogram for y filter. [32 FLOAT].
+- name: uLcNonPeriodic
+  type: BLOB
+  nullable: true
+  description: Non-periodic features extracted from light-curves using generalized
+    Lomb-Scargle periodogram for u filter. [20 FLOAT].
+- name: gLcNonPeriodic
+  type: BLOB
+  nullable: true
+  description: Non-periodic features extracted from light-curves using generalized
+    Lomb-Scargle periodogram for g filter. [20 FLOAT].
+- name: rLcNonPeriodic
+  type: BLOB
+  nullable: true
+  description: Non-periodic features extracted from light-curves using generalized
+    Lomb-Scargle periodogram for r filter. [20 FLOAT].
+- name: iLcNonPeriodic
+  type: BLOB
+  nullable: true
+  description: Non-periodic features extracted from light-curves using generalized
+    Lomb-Scargle periodogram for i filter. [20 FLOAT].
+- name: zLcNonPeriodic
+  type: BLOB
+  nullable: true
+  description: Non-periodic features extracted from light-curves using generalized
+    Lomb-Scargle periodogram for z filter. [20 FLOAT].
+- name: yLcNonPeriodic
+  type: BLOB
+  nullable: true
+  description: Non-periodic features extracted from light-curves using generalized
+    Lomb-Scargle periodogram for y filter. [20 FLOAT].
+- name: nearbyObj1
+  type: BIGINT
+  nullable: true
+  description: Id of the closest nearby object.
+  ucd: meta.id;src
+- name: nearbyObj1Dist
+  type: FLOAT
+  nullable: true
+  description: Distance to nearbyObj1.
+  unit: arcsec
+- name: nearbyObj1LnP
+  type: FLOAT
+  nullable: true
+  description: Natural log of the probability that the observed diaObject is the same
+    as the nearbyObj1.
+- name: nearbyObj2
+  type: BIGINT
+  nullable: true
+  description: Id of the second-closest nearby object.
+  ucd: meta.id;src
+- name: nearbyObj2Dist
+  type: FLOAT
+  nullable: true
+  description: Distance to nearbyObj2.
+  unit: arcsec
+- name: nearbyObj2LnP
+  type: FLOAT
+  nullable: true
+  description: Natural log of the probability that the observed diaObject is the same
+    as the nearbyObj2.
+- name: nearbyObj3
+  type: BIGINT
+  nullable: true
+  description: Id of the third-closest nearby object.
+  ucd: meta.id;src
+- name: nearbyObj3Dist
+  type: FLOAT
+  nullable: true
+  description: Distance to nearbyObj3.
+  unit: arcsec
+- name: nearbyObj3LnP
+  type: FLOAT
+  nullable: true
+  description: Natural log of the probability that the observed diaObject is the same
+    as the nearbyObj3.
+- name: flags
+  type: BIGINT
+  nullable: false
+  default: '0'
+  description: Flags, bitwise OR tbd.
+  ucd: meta.code
+- name: htmId20
+  type: BIGINT
+  nullable: false
+  description: HTM index.
+indices:
+- name: PK_DiaObject
+  columns:
+  - diaObjectId
+  - validityStart
+  type: PRIMARY
+- name: IDX_DiaObject_validityStart
+  columns:
+  - validityStart
+  type: INDEX
+- name: IDX_DiaObject_htmId20
+  columns:
+  - htmId20
+  type: INDEX
+---
+table: SSObject
+description: The SSObject table contains description of the Solar System (moving)
+  Objects.
+columns:
+- name: ssObjectId
+  type: BIGINT
+  nullable: false
+  description: Unique identifier.
+  ucd: meta.id;src
+- name: q
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: qSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of q.
+  ucd: stat.error
+- name: e
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: eSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of e.
+  ucd: stat.error
+- name: i
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: iSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of i.
+  ucd: stat.error
+- name: lan
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: lanSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of lan.
+  ucd: stat.error
+- name: aop
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: aopSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of aop.
+  ucd: stat.error
+- name: M
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: MSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of M.
+  ucd: stat.error
+- name: epoch
+  type: DOUBLE
+  nullable: true
+  description: Osculating orbital elements at epoch (q, e, i, lan, aop, M, epoch).
+- name: epochSigma
+  type: DOUBLE
+  nullable: true
+  description: Uncertainty of epoch.
+  ucd: stat.error
+- name: q_e_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of q and e.
+  ucd: stat.covariance
+- name: q_i_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of q and i.
+  ucd: stat.covariance
+- name: q_lan_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of q and lan.
+  ucd: stat.covariance
+- name: q_aop_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of q and aop.
+  ucd: stat.covariance
+- name: q_M_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of q and M.
+  ucd: stat.covariance
+- name: q_epoch_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of q and epoch.
+  ucd: stat.covariance
+- name: e_i_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of e and i.
+  ucd: stat.covariance
+- name: e_lan_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of e and lan.
+  ucd: stat.covariance
+- name: e_aop_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of e and aop.
+  ucd: stat.covariance
+- name: e_M_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of e and M.
+  ucd: stat.covariance
+- name: e_epoch_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of e and epoch.
+  ucd: stat.covariance
+- name: i_lan_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of i and lan.
+  ucd: stat.covariance
+- name: i_aop_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of i and aop.
+  ucd: stat.covariance
+- name: i_M_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of i and M.
+  ucd: stat.covariance
+- name: i_epoch_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of i and epoch.
+  ucd: stat.covariance
+- name: lan_aop_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of lan and aop.
+  ucd: stat.covariance
+- name: lan_M_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of lan and M.
+  ucd: stat.covariance
+- name: lan_epoch_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of lan and epoch.
+  ucd: stat.covariance
+- name: aop_M_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of aop and M.
+  ucd: stat.covariance
+- name: aop_epoch_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of aop and epoch.
+  ucd: stat.covariance
+- name: M_epoch_Cov
+  type: DOUBLE
+  nullable: true
+  description: Covariance of M and epoch.
+  ucd: stat.covariance
+- name: arc
+  type: FLOAT
+  nullable: true
+  description: Arc of observation.
+  unit: days
+- name: orbFitLnL
+  type: FLOAT
+  nullable: true
+  description: Natural log of the likelihood of the orbital elements fit.
+  ucd: stat.likelihood
+- name: orbFitChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic of the orbital elements fit.
+  ucd: stat.fit.chi2
+- name: orbFitNdata
+  type: INTEGER
+  nullable: true
+  description: Number of observations used in the fit.
+- name: MOID1
+  type: FLOAT
+  nullable: true
+  description: Minimum orbit intersection distance.
+  unit: AU
+- name: MOID2
+  type: FLOAT
+  nullable: true
+  description: Minimum orbit intersection distance.
+  unit: AU
+- name: moidLon1
+  type: DOUBLE
+  nullable: true
+  description: MOID longitudes.
+  unit: deg
+- name: moidLon2
+  type: DOUBLE
+  nullable: true
+  description: MOID longitudes.
+  unit: deg
+- name: uH
+  type: FLOAT
+  nullable: true
+  description: Mean absolute magnitude for u filter.
+  unit: mag
+- name: uHErr
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of uH estimate.
+  ucd: stat.error
+  unit: mag
+- name: uG1
+  type: FLOAT
+  nullable: true
+  description: Fitted G1 slope parameter for u filter.
+  unit: mag
+- name: uG1Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of uG1 estimate.
+  ucd: stat.error
+  unit: mag
+- name: uG2
+  type: FLOAT
+  nullable: true
+  description: Fitted G2 slope parameter for u filter.
+  unit: mag
+- name: uG2Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of uG2 estimate.
+  ucd: stat.error
+  unit: mag
+- name: gH
+  type: FLOAT
+  nullable: true
+  description: Mean absolute magnitude for g filter.
+  unit: mag
+- name: gHErr
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of gH estimate.
+  ucd: stat.error
+  unit: mag
+- name: gG1
+  type: FLOAT
+  nullable: true
+  description: Fitted G1 slope parameter for g filter.
+  unit: mag
+- name: gG1Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of gG1 estimate.
+  ucd: stat.error
+  unit: mag
+- name: gG2
+  type: FLOAT
+  nullable: true
+  description: Fitted G2 slope parameter for g filter.
+  unit: mag
+- name: gG2Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of gG2 estimate.
+  ucd: stat.error
+  unit: mag
+- name: rH
+  type: FLOAT
+  nullable: true
+  description: Mean absolute magnitude for r filter.
+  unit: mag
+- name: rHErr
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of rH estimate.
+  ucd: stat.error
+  unit: mag
+- name: rG1
+  type: FLOAT
+  nullable: true
+  description: Fitted G1 slope parameter for r filter.
+  unit: mag
+- name: rG1Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of rG1 estimate.
+  ucd: stat.error
+  unit: mag
+- name: rG2
+  type: FLOAT
+  nullable: true
+  description: Fitted G2 slope parameter for r filter.
+  unit: mag
+- name: rG2Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of rG2 estimate.
+  ucd: stat.error
+  unit: mag
+- name: iH
+  type: FLOAT
+  nullable: true
+  description: Mean absolute magnitude for i filter.
+  unit: mag
+- name: iHErr
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of iH estimate.
+  ucd: stat.error
+  unit: mag
+- name: iG1
+  type: FLOAT
+  nullable: true
+  description: Fitted G1 slope parameter for i filter.
+  unit: mag
+- name: iG1Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of iG1 estimate.
+  ucd: stat.error
+  unit: mag
+- name: iG2
+  type: FLOAT
+  nullable: true
+  description: Fitted G2 slope parameter for i filter.
+  unit: mag
+- name: iG2Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of iG2 estimate.
+  ucd: stat.error
+  unit: mag
+- name: zH
+  type: FLOAT
+  nullable: true
+  description: Mean absolute magnitude for z filter.
+  unit: mag
+- name: zHErr
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of zH estimate.
+  ucd: stat.error
+  unit: mag
+- name: zG1
+  type: FLOAT
+  nullable: true
+  description: Fitted G1 slope parameter for z filter.
+  unit: mag
+- name: zG1Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of zG1 estimate.
+  ucd: stat.error
+  unit: mag
+- name: zG2
+  type: FLOAT
+  nullable: true
+  description: Fitted G2 slope parameter for z filter.
+  unit: mag
+- name: zG2Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of zG2 estimate.
+  ucd: stat.error
+  unit: mag
+- name: yH
+  type: FLOAT
+  nullable: true
+  description: Mean absolute magnitude for y filter.
+  unit: mag
+- name: yHErr
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of yH estimate.
+  ucd: stat.error
+  unit: mag
+- name: yG1
+  type: FLOAT
+  nullable: true
+  description: Fitted G1 slope parameter for y filter.
+  unit: mag
+- name: yG1Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of yG1 estimate.
+  ucd: stat.error
+  unit: mag
+- name: yG2
+  type: FLOAT
+  nullable: true
+  description: Fitted G2 slope parameter for y filter.
+  unit: mag
+- name: yG2Err
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of yG2 estimate.
+  ucd: stat.error
+  unit: mag
+- name: flags
+  type: BIGINT
+  nullable: false
+  default: '0'
+  description: Flags, bitwise OR tbd.
+  ucd: meta.code
+indices:
+- name: PK_SSObject
+  columns:
+  - ssObjectId
+  type: PRIMARY
+---
+table: DiaSource
+description: Table to store 'difference image sources'; - sources detected at SNR
+  >=5 on difference images.
+columns:
+- name: diaSourceId
+  type: BIGINT
+  nullable: false
+  description: Unique id.
+  ucd: meta.id;obs.image
+- name: ccdVisitId
+  type: BIGINT
+  nullable: false
+  description: Id of the ccdVisit where this diaSource was measured. Note that we
+    are allowing a diaSource to belong to multiple amplifiers, but it may not span
+    multiple ccds.
+  ucd: meta.id;obs.image
+- name: diaObjectId
+  type: BIGINT
+  nullable: true
+  description: Id of the diaObject this source was associated with, if any. If not,
+    it is set to NULL (each diaSource will be associated with either a diaObject or
+    ssObject).
+  ucd: meta.id;src
+- name: ssObjectId
+  type: BIGINT
+  nullable: true
+  description: Id of the ssObject this source was associated with, if any. If not,
+    it is set to NULL (each diaSource will be associated with either a diaObject or
+    ssObject).
+  ucd: meta.id;src
+- name: parentDiaSourceId
+  type: BIGINT
+  nullable: true
+  description: Id of the parent diaSource this diaSource has been deblended from,
+    if any.
+  ucd: meta.id;src
+- name: prv_procOrder
+  type: INT
+  nullable: false
+  description: Position of this diaSource in the processing order relative to other
+    diaSources within a given diaObjectId or ssObjectId.
+- name: ssObjectReassocTime
+  type: DATETIME
+  nullable: true
+  description: Time when this diaSource was reassociated from diaObject to ssObject
+    (if such reassociation happens, otherwise NULL).
+- name: midPointTai
+  type: DOUBLE
+  nullable: false
+  description: Effective mid-exposure time for this diaSource.
+  ucd: time.epoch
+  unit: d
+- name: ra
+  type: DOUBLE
+  nullable: false
+  description: RA-coordinate of the center of this diaSource.
+  ucd: pos.eq.ra
+  unit: deg
+- name: raSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of ra.
+  ucd: stat.error;pos.eq.ra
+  unit: deg
+- name: decl
+  type: DOUBLE
+  nullable: false
+  description: ' Decl-coordinate of the center of this diaSource.'
+  ucd: pos.eq.dec
+  unit: deg
+- name: declSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of decl.
+  ucd: stat.error;pos.eq.dec
+  unit: deg
+- name: ra_decl_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance between ra and decl.
+  ucd: stat.covariance
+  unit: deg^2
+- name: x
+  type: FLOAT
+  nullable: false
+  description: x position computed by a centroiding algorithm.
+  ucd: pos.cartesian.x
+  unit: pixel
+- name: xSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of x.
+  ucd: stat.error:pos.cartesian.x
+  unit: pixel
+- name: y
+  type: FLOAT
+  nullable: false
+  description: y position computed by a centroiding algorithm.
+  ucd: pos.cartesian.y
+  unit: pixel
+- name: ySigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of y.
+  ucd: stat.error:pos.cartesian.y
+  unit: pixel
+- name: x_y_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance between x and y.
+  ucd: stat.covariance
+  unit: pixel^2
+- name: apFlux
+  type: FLOAT
+  nullable: false
+  description: Calibrated aperture flux. Note that this actually measures the difference
+    between the template and the visit image.
+  ucd: phot.count
+  unit: nmgy
+- name: apFluxErr
+  type: FLOAT
+  nullable: false
+  description: Estimated uncertainty of apFlux.
+  ucd: stat.error;phot.count
+  unit: nmgy
+- name: snr
+  type: FLOAT
+  nullable: false
+  description: The signal-to-noise ratio at which this source was detected in the
+    difference image.
+  ucd: stat.snr
+- name: psFlux
+  type: FLOAT
+  nullable: true
+  description: Calibrated flux for Point Source model. Note this actually measures
+    the flux difference between the template and the visit image.
+  ucd: phot.count
+  unit: nmgy
+- name: psFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of psFlux.
+  unit: nmgy
+- name: psRa
+  type: DOUBLE
+  nullable: true
+  description: ' RA-coordinate of centroid for point source model.'
+  ucd: pos.eq.ra
+  unit: deg
+- name: psRaSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of psRa.
+  ucd: stat.error;pos.eq.ra
+  unit: deg
+- name: psDecl
+  type: DOUBLE
+  nullable: true
+  description: ' Decl-coordinate of centroid for point source model.'
+  ucd: pos.eq.dec
+  unit: deg
+- name: psDeclSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of psDecl.
+  ucd: stat.error;pos.eq.dec
+  unit: deg
+- name: psFlux_psRa_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance between psFlux and psRa.
+  ucd: stat.covariance
+  unit: ngmy*deg
+- name: psFlux_psDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance between psFlux and psDecl.
+  ucd: stat.covariance
+  unit: ngmy*deg
+- name: psRa_psDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance between psRa and psDecl.
+  ucd: stat.covariance
+  unit: deg^2
+- name: psLnL
+  type: FLOAT
+  nullable: true
+  description: Natural log likelihood of the observed data given the Point Source
+    model.
+  ucd: stat.likelihood
+- name: psChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic of the model fit.
+  ucd: stat.fit.chi2
+- name: psNdata
+  type: INT
+  nullable: true
+  description: The number of data points (pixels) used to fit the model.
+- name: trailFlux
+  type: FLOAT
+  nullable: true
+  description: Calibrated flux for a trailed source model. Note this actually measures
+    the flux difference between the template and the visit image.
+  unit: nmgy
+- name: trailFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of trailFlux.
+  unit: nmgy
+- name: trailRa
+  type: DOUBLE
+  nullable: true
+  description: ' RA-coordinate of centroid for trailed source model.'
+  ucd: pos.eq.ra
+  unit: deg
+- name: trailRaSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of trailRa.
+  ucd: stat.error;pos.eq.ra
+  unit: deg
+- name: trailDecl
+  type: DOUBLE
+  nullable: true
+  description: ' Decl-coordinate of centroid for trailed source model.'
+  ucd: pos.eq.dec
+  unit: deg
+- name: trailDeclSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of trailDecl.
+  ucd: stat.error;pos.eq.dec
+  unit: deg
+- name: trailLength
+  type: FLOAT
+  nullable: true
+  description: Maximum likelihood fit of trail length.
+  unit: arcsec
+- name: trailLengthSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of trailLength.
+  unit: nmgy
+- name: trailAngle
+  type: FLOAT
+  nullable: true
+  description: Maximum likelihood fit of the angle between the meridian through the
+    centroid and the trail direction (bearing).
+  unit: deg
+- name: trailAngleSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of trailAngle.
+  unit: nmgy
+- name: trailFlux_trailRa_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailFlux and trailRa.
+  ucd: stat.covariance
+- name: trailFlux_trailDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailFlux and trailDecl.
+  ucd: stat.covariance
+- name: trailFlux_trailLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailFlux and trailLength
+  ucd: stat.covariance
+- name: trailFlux_trailAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailFlux and trailAngle
+  ucd: stat.covariance
+- name: trailRa_trailDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailRa and trailDecl.
+  ucd: stat.covariance
+- name: trailRa_trailLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailRa and trailLength.
+  ucd: stat.covariance
+- name: trailRa_trailAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailRa and trailAngle.
+  ucd: stat.covariance
+- name: trailDecl_trailLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailDecl and trailLength.
+  ucd: stat.covariance
+- name: trailDecl_trailAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailDecl and trailAngle.
+  ucd: stat.covariance
+- name: trailLength_trailAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of trailLength and trailAngle
+  ucd: stat.covariance
+- name: trailLnL
+  type: FLOAT
+  nullable: true
+  description: Natural log likelihood of the observed data given the trailed source
+    model.
+  ucd: stat.likelihood
+- name: trailChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic of the model fit.
+  ucd: stat.fit.chi2
+- name: trailNdata
+  type: INT
+  nullable: true
+  description: The number of data points (pixels) used to fit the model.
+- name: dipMeanFlux
+  type: FLOAT
+  nullable: true
+  description: Maximum likelihood value for the mean absolute flux of the two lobes
+    for a dipole model.
+  unit: nmgy
+- name: dipMeanFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of dipMeanFlux.
+  ucd: stat.error
+  unit: nmgy
+- name: dipFluxDiff
+  type: FLOAT
+  nullable: true
+  description: Maximum likelihood value for the difference of absolute fluxes of the
+    two lobes for a dipole model.
+  unit: nmgy
+- name: dipFluxDiffSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of dipFluxDiff.
+  ucd: stat.error
+  unit: nmgy
+- name: dipRa
+  type: DOUBLE
+  nullable: true
+  description: ' RA-coordinate of centroid for dipole model.'
+  ucd: pos.eq.ra
+  unit: deg
+- name: dipRaSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of trailRa.
+  ucd: stat.error;pos.eq.ra
+  unit: deg
+- name: dipDecl
+  type: DOUBLE
+  nullable: true
+  description: ' Decl-coordinate of centroid for dipole model.'
+  ucd: pos.eq.dec
+  unit: deg
+- name: dipDeclSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of dipDecl.
+  ucd: stat.error;pos.eq.dec
+  unit: deg
+- name: dipLength
+  type: FLOAT
+  nullable: true
+  description: Maximum likelihood value for the lobe separation in dipole model.
+  ucd: pos.angDistance
+  unit: arcsec
+- name: dipLengthSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of dipLength.
+  ucd: stat.error;pos.angDistance
+  unit: arcsec
+- name: dipAngle
+  type: FLOAT
+  nullable: true
+  description: Maximum likelihood fit of the angle between the meridian through the
+    centroid and the dipole direction (bearing, from negative to positive lobe).
+  ucd: pos.posAng
+  unit: deg
+- name: dipAngleSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of dipAngle.
+  ucd: stat.error;pos.posAng
+  unit: deg
+- name: dipMeanFlux_dipFluxDiff_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipMeanFlux and dipFluxDiff.
+  ucd: stat.covariance
+- name: dipMeanFlux_dipRa_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipMeanFlux and dipRa.
+  ucd: stat.covariance
+- name: dipMeanFlux_dipDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipMeanFlux and dipDecl.
+  ucd: stat.covariance
+- name: dipMeanFlux_dipLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipMeanFlux and dipLength.
+  ucd: stat.covariance
+- name: dipMeanFlux_dipAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipMeanFlux and dipAngle.
+  ucd: stat.covariance
+- name: dipFluxDiff_dipRa_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipFluxDiff and dipRa.
+  ucd: stat.covariance
+- name: dipFluxDiff_dipDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipFluxDiff and dipDecl.
+  ucd: stat.covariance
+- name: dipFluxDiff_dipLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipFluxDiff and dipLength.
+  ucd: stat.covariance
+- name: dipFluxDiff_dipAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipFluxDiff and dipAngle.
+  ucd: stat.covariance
+- name: dipRa_dipDecl_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipRa and dipDecl.
+  ucd: stat.covariance
+- name: dipRa_dipLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipRa and dipLength.
+  ucd: stat.covariance
+- name: dipRa_dipAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipRa and dipAngle.
+  ucd: stat.covariance
+- name: dipDecl_dipLength_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipDecl and dipLength.
+  ucd: stat.covariance
+- name: dipDecl_dipAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipDecl and dipAngle.
+  ucd: stat.covariance
+- name: dipLength_dipAngle_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of dipLength and dipAngle.
+  ucd: stat.covariance
+- name: dipLnL
+  type: FLOAT
+  nullable: true
+  description: Natural log likelihood of the observed data given the dipole source
+    model.
+  ucd: stat.likelihood
+- name: dipChi2
+  type: FLOAT
+  nullable: true
+  description: Chi^2 statistic of the model fit.
+  ucd: stat.fit.chi2
+- name: dipNdata
+  type: INT
+  nullable: true
+  description: The number of data points (pixels) used to fit the model.
+- name: totFlux
+  type: FLOAT
+  nullable: true
+  description: Calibrated flux for Point Source model measured on the visit image
+    centered at the centroid measured on the difference image (forced photometry flux).
+  ucd: phot.count
+  unit: nmgy
+- name: totFluxErr
+  type: FLOAT
+  nullable: true
+  description: Estimated uncertainty of totFlux.
+  ucd: stat.error;phot.count
+  unit: nmgy
+- name: diffFlux
+  type: FLOAT
+  nullable: true
+  description: Calibrated flux for Point Source model centered on radec but measured
+    on the difference of snaps comprising this visit.
+  unit: nmgy
+- name: diffFluxErr
+  type: FLOAT
+  nullable: true
+  description: Estimated uncertainty of diffFlux.
+  ucd: stat.error;phot.count
+  unit: nmgy
+- name: fpBkgd
+  type: FLOAT
+  nullable: true
+  description: Estimated sky background at the position (centroid) of the object.
+  unit: nmgy/asec^2
+- name: fpBkgdErr
+  type: FLOAT
+  nullable: true
+  description: Estimated uncertainty of fpBkgd.
+  unit: nmgy/asec^2
+- name: ixx
+  type: FLOAT
+  nullable: true
+  description: Adaptive second moment of the source intensity.
+  unit: nmgy*asec^2
+- name: ixxSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of ixx.
+  ucd: stat.error
+  unit: nmgy*asec^2
+- name: iyy
+  type: FLOAT
+  nullable: true
+  description: Adaptive second moment of the source intensity.
+  unit: nmgy*asec^2
+- name: iyySigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of iyy.
+  ucd: stat.error
+  unit: nmgy*asec^2
+- name: ixy
+  type: FLOAT
+  nullable: true
+  description: Adaptive second moment of the source intensity.
+  unit: nmgy*asec^2
+- name: ixySigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of ixy.
+  ucd: stat.error
+  unit: nmgy*asec^2
+- name: ixx_iyy_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of ixx and iyy.
+  unit: nmgy^2*asec^4
+- name: ixx_ixy_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of ixx and ixy.
+  unit: nmgy^2*asec^4
+- name: iyy_ixy_Cov
+  type: FLOAT
+  nullable: true
+  description: Covariance of iyy and ixy.
+  unit: nmgy^2*asec^4
+- name: ixxPSF
+  type: FLOAT
+  nullable: true
+  description: Adaptive second moment for the PSF.
+  unit: nmgy*asec^2
+- name: iyyPSF
+  type: FLOAT
+  nullable: true
+  description: Adaptive second moment for the PSF.
+  unit: nmgy*asec^2
+- name: ixyPSF
+  type: FLOAT
+  nullable: true
+  description: Adaptive second moment for the PSF.
+  unit: nmgy*asec^2
+- name: extendedness
+  type: FLOAT
+  nullable: true
+  description: A measure of extendedness, Computed using a combination of available
+    moments and model fluxes or from a likelihood ratio of point/trailed source models
+    (exact algorithm TBD). extendedness = 1 implies a high degree of confidence that
+    the source is extended. extendedness = 0 implies a high degree of confidence that
+    the source is point-like.
+- name: spuriousness
+  type: FLOAT
+  nullable: true
+  description: A measure of spuriousness, computed using information from the source
+    and image characterization, as well as the information on the Telescope and Camera
+    system (e.g., ghost maps, defect maps, etc.).
+- name: flags
+  type: BIGINT
+  nullable: false
+  default: '0'
+  description: Flags, bitwise OR tbd.
+  ucd: meta.code
+- name: htmId20
+  type: BIGINT
+  nullable: false
+  description: HTM index.
+indices:
+- name: PK_DiaSource
+  columns:
+  - diaSourceId
+  type: PRIMARY
+- name: IDX_DiaSource_ccdVisitId
+  columns:
+  - ccdVisitId
+  type: INDEX
+- name: IDX_DiaSource_diaObjectId
+  columns:
+  - diaObjectId
+  type: INDEX
+- name: IDX_DiaSource_ssObjectId
+  columns:
+  - ssObjectId
+  type: INDEX
+- name: IDX_DiaSource_htmId20
+  columns:
+  - htmId20
+  type: INDEX
+---
+table: DiaForcedSource
+description: Forced-photometry source measurement on an individual difference Exposure
+  based on a Multifit shape model derived from a deep detection.
+columns:
+- name: diaObjectId
+  type: BIGINT
+  nullable: false
+  ucd: meta.id;src
+- name: ccdVisitId
+  type: BIGINT
+  nullable: false
+  description: Id of the visit where this forcedSource was measured. Note that we
+    are allowing a forcedSource to belong to multiple amplifiers, but it may not span
+    multiple ccds.
+  ucd: meta.id;obs.image
+- name: psFlux
+  type: FLOAT
+  nullable: false
+  description: Point Source model flux.
+  ucd: phot.count
+  unit: nmgy
+- name: psFluxSigma
+  type: FLOAT
+  nullable: true
+  description: Uncertainty of psFlux.
+  ucd: stat.error;phot.count
+  unit: nmgy
+- name: x
+  type: FLOAT
+  nullable: false
+  description: x position at which psFlux has been measured.
+  ucd: pos.cartesian.x
+  unit: pixel
+- name: y
+  type: FLOAT
+  nullable: false
+  description: y position at which psFlux has been measured.
+  ucd: pos.cartesian.y
+  unit: pixel
+- name: flags
+  type: BIGINT
+  nullable: false
+  default: '0'
+  description: Flags, bitwise OR tbd
+  ucd: meta.code
+indices:
+- name: PK_DiaForcedSource
+  columns:
+  - diaObjectId
+  - ccdVisitId
+  type: PRIMARY
+- name: IDX_DiaForcedSource_ccdVisitId
+  columns:
+  - ccdVisitId
+  type: INDEX
+---
+table: DiaObject_To_Object_Match
+description: The table stores mapping of diaObjects to the nearby objects.
+columns:
+- name: diaObjectId
+  type: BIGINT
+  nullable: false
+  description: Id of diaObject.
+  ucd: meta.id;src
+- name: objectId
+  type: BIGINT
+  nullable: false
+  description: Id of a nearby object.
+  ucd: meta.id;src
+- name: dist
+  type: FLOAT
+  nullable: false
+  description: The distance between the diaObject and the object.
+  unit: arcsec
+- name: lnP
+  type: FLOAT
+  nullable: true
+  description: Natural log of the probability that the observed diaObject is the same
+    as the nearby object.
+indices:
+- name: IDX_DiaObjectToObjectMatch_diaObjectId
+  columns:
+  - diaObjectId
+  type: INDEX
+- name: IDX_DiaObjectToObjectMatch_objectId
+  columns:
+  - objectId
+  type: INDEX

--- a/python/lsst/l1dbproto/DIA.py
+++ b/python/lsst/l1dbproto/DIA.py
@@ -75,7 +75,7 @@ class DIA(object):
 
         var_indices = numpy.nonzero(products > cos_open)
 
-        n_trans = numpy.random.poisson(self._n_trans, 1)
+        n_trans = numpy.random.poisson(self._n_trans)
         transients = generators.rand_cone_xyz(self._xyz, self._open_angle, n_trans)
 
         sources = numpy.concatenate((self._vars[var_indices], transients))

--- a/python/lsst/l1dbproto/l1db.py
+++ b/python/lsst/l1dbproto/l1db.py
@@ -625,15 +625,22 @@ class L1db(object):
             cursor = connection.cursor()
             cursor.execute("VACUUM ANALYSE")
 
-    def makeSchema(self, drop=False, mysql_engine='InnoDB'):
+    def makeSchema(self, schema_dict=None, drop=False, mysql_engine='InnoDB'):
         """Create or re-create all tables.
 
         Parameters
         ----------
+        schema_dict : `dict`, optional
+            Dictionary with table name for a key and `afw.table.Schema`
+            for a value. Columns in schema will be added to standard
+            L1DB schema.
         drop : boolean
             If True then drop tables before creating new ones.
+        mysql_engine : `str`, optional
+            Name of the MySQL engine to use for new tables.
         """
-        self._schema.makeSchema(drop=drop, mysql_engine=mysql_engine)
+        self._schema.makeSchema(schema_dict=schema_dict, drop=drop,
+                                mysql_engine=mysql_engine)
 
     def _explain(self, query, conn):
         # run the query with explain

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -46,8 +46,15 @@ class L1dbSchema(object):
         default look for $L1DBPROTO_DIR/data/l1db-schema-extra.yaml file.
     """
 
+    # map afw type names into cat type names
+    _afw_type_map = dict(I="INT",
+                         L="BIGINT",
+                         F="FLOAT",
+                         D="DOUBLE",
+                         Angle="DOUBLE")
+
     def __init__(self, engine, dia_object_index, dia_object_nightly,
-                 schema_file=None, extra_schema_file=None):
+                 schema_file=None, extra_schema_file=None, column_map=None):
 
         self._engine = engine
         self._dia_object_index = dia_object_index
@@ -63,40 +70,59 @@ class L1dbSchema(object):
         if not extra_schema_file:
             extra_schema_file = os.path.join(os.environ.get("L1DBPROTO_DIR"),
                                              "data", "l1db-schema-extra.yaml")
+        if not column_map:
+            column_map = os.path.join(os.environ.get("L1DBPROTO_DIR"),
+                                      "data", "l1db-afw-map.yaml")
+
         _LOG.debug("Reading schema file %s", schema_file)
-        with open(schema_file) as schema_stream:
-            tables = list(yaml.load_all(schema_stream))
+        with open(schema_file) as yaml_stream:
+            tables = list(yaml.load_all(yaml_stream))
             # index it by table name
             self._schemas = {table['table']: table for table in tables}
         _LOG.debug("Read %d tables from schema", len(self._schemas))
 
         _LOG.debug("Reading schema file %s", extra_schema_file)
-        with open(extra_schema_file) as schema_stream:
-            tables = list(yaml.load_all(schema_stream))
+        with open(extra_schema_file) as yaml_stream:
+            tables = list(yaml.load_all(yaml_stream))
             # index it by table name
             self._schemas_extra = {table['table']: table for table in tables}
 
-    def makeSchema(self, drop=False, mysql_engine='InnoDB'):
+        _LOG.debug("Reading column map file %s", column_map)
+        with open(column_map) as yaml_stream:
+            self._column_map = yaml.load(yaml_stream)
+            _LOG.debug("column map: %s", self._column_map)
+        self._column_map_reverse = {}
+        for table, cmap in self._column_map.items():
+            self._column_map_reverse[table] = {v: k for k, v in cmap.items()}
+        _LOG.debug("reverse column map: %s", self._column_map_reverse)
+
+        # map cat column types to alchemy
+        self._type_map = dict(DOUBLE=self._make_doube_type(),
+                              FLOAT=sqlalchemy.types.Float,
+                              DATETIME=sqlalchemy.types.TIMESTAMP,
+                              BIGINT=sqlalchemy.types.BigInteger,
+                              INTEGER=sqlalchemy.types.Integer,
+                              INT=sqlalchemy.types.Integer,
+                              TINYINT=sqlalchemy.types.Integer,
+                              BLOB=sqlalchemy.types.LargeBinary,
+                              CHAR=sqlalchemy.types.CHAR)
+
+    def makeSchema(self, schema_dict=None, drop=False, mysql_engine='InnoDB'):
         """Create or re-create all tables.
 
         Parameters
         ----------
+        schema_dict : `dict`, optional
+            Dictionary with table name for a key and `afw.table.Schema`
+            for a value. Columns in schema will be added to standard
+            L1DB schema.
         drop : boolean
             If True then drop tables before creating new ones.
         mysql_engine : `str`
             MySQL engine type to use for new tables.
         """
-        # map cat column types to alchemy
-        type_map = dict(DOUBLE=self._make_doube_type(),
-                        FLOAT=sqlalchemy.types.Float,
-                        DATETIME=sqlalchemy.types.TIMESTAMP,
-                        BIGINT=sqlalchemy.types.BigInteger,
-                        INTEGER=sqlalchemy.types.Integer,
-                        INT=sqlalchemy.types.Integer,
-                        TINYINT=sqlalchemy.types.Integer,
-                        BLOB=sqlalchemy.types.LargeBinary,
-                        CHAR=sqlalchemy.types.CHAR)
 
+        afw_schema = schema_dict.get('DiaObject')
         if self._dia_object_index == 'htm20_id_iov':
             constraints = [PrimaryKeyConstraint('htmId20', 'diaObjectId', 'validityStart',
                                                 name='PK_DiaObject'),
@@ -106,26 +132,27 @@ class L1dbSchema(object):
                            Index('IDX_DiaObject_validityStart', 'validityStart'),
                            Index('IDX_DiaObject_htmId20', 'htmId20')]
         table = Table('DiaObject', self._metadata,
-                      *(self._table_columns('DiaObject', type_map) + constraints),
+                      *(self._table_columns('DiaObject', afw_schema) + constraints),
                       mysql_engine=mysql_engine)
 
         if self._dia_object_nightly:
             table = Table('DiaObjectNightly', self._metadata,
-                          *self._table_columns('DiaObject', type_map),
+                          *self._table_columns('DiaObject', afw_schema),
                           mysql_engine=mysql_engine)
 
         if self._dia_object_index == 'last_object_table':
             constraints = [PrimaryKeyConstraint('htmId20', 'diaObjectId', name='PK_DiaObjectLast'),
                            Index('IDX_DiaObjectLast_diaObjectId', 'diaObjectId')]
             table = Table('DiaObjectLast', self._metadata,
-                          *(self._table_columns('DiaObject', type_map) + constraints),
+                          *(self._table_columns('DiaObject', afw_schema) + constraints),
                           mysql_engine=mysql_engine)
 
         # for all other tables use index definitions in schema
         for table_name in ('DiaSource', 'SSObject', 'DiaForcedSource', 'DiaObject_To_Object_Match'):
+            afw_schema = schema_dict.get(table_name)
             table = Table(table_name, self._metadata,
-                          *(self._table_columns(table_name, type_map) +
-                            self._table_indices(table_name, type_map)),
+                          *(self._table_columns(table_name, afw_schema) +
+                            self._table_indices(table_name)),
                           mysql_engine=mysql_engine)
 
         # special table to track visits, only used by prototype
@@ -179,21 +206,25 @@ class L1dbSchema(object):
         """
         return self._table_schema('DiaForcedSource')
 
-    def _table_columns(self, table_name, type_map):
+    def _table_columns(self, table_name, afw_schema):
         """Return set of columns in a table
 
         Parameters
         ----------
         table_name : `str`
             Name of the table.
-        type_map : `dict`
-            Mapping of the cat column type names into alchemy columns
+        afw_schema : `afw.table.Schema`, optional
+            Schema used by AP pipeline, if there are any columns in the
+            schema not defined in standard (cat) schema they will be added
+            to the new tables.
 
         Returns
         -------
         List of `Column` objects.
         """
 
+        # get the list of columns in primary key, they are treated somewhat
+        # specially below
         table_schema = self._schemas[table_name]
         pkey_columns = set()
         for index in table_schema.get('indices', []):
@@ -201,7 +232,7 @@ class L1dbSchema(object):
                 pkey_columns = set(index['columns'])
                 break
 
-        # columns in _EXTRA_COLUMS can override cat definitions, and I also want
+        # columns in _schemas_extra can override cat definitions, and I also want
         # to preserve order of the original cat schema so it's a bit messy
         columns = table_schema['columns']
         if table_name in self._schemas_extra:
@@ -209,13 +240,21 @@ class L1dbSchema(object):
             extra_columns = {col['name']: col for col in extra_columns}
             _LOG.debug("Extra columns for table %s: %s", table_name, extra_columns.keys())
             columns = []
-            used = set()
             for col in table_schema['columns']:
                 if col['name'] in extra_columns:
                     columns.append(extra_columns.pop(col['name']))
                 else:
                     columns.append(col)
+            # add all remaining extra columns
             columns += extra_columns.values()
+
+        if afw_schema:
+            # use afw schema to create extra columns
+            column_names = {col['name'] for col in columns}
+            for k, field in afw_schema:
+                column = self._field2dict(field, table_name)
+                if column['name'] not in column_names:
+                    columns.append(column)
 
         # convert all column dicts into alchemy Columns
         column_defs = []
@@ -223,20 +262,26 @@ class L1dbSchema(object):
             kwargs = dict(nullable=column['nullable'])
             if column['name'] in pkey_columns:
                 kwargs.update(autoincrement=False)
-            ctype = type_map[column['type']]
+            ctype = self._type_map[column['type']]
             column_defs.append(Column(column['name'], ctype, **kwargs))
 
         return column_defs
 
-    def _table_indices(self, table_name, type_map):
+    def _field2dict(self, field, table_name):
+        """Convert afw schema field definition into a dict format.
+        """
+        column = field.getName()
+        column = self._column_map_reverse[table_name].get(column, column)
+        type = self._afw_type_map[field.getTypeString()]
+        return dict(name=column, type=type, nullable=True, default=None)
+
+    def _table_indices(self, table_name):
         """Return set of constraints/indices in a table
 
         Parameters
         ----------
         table_name : `str`
             Name of the table.
-        type_map : `dict`
-            Mapping of the cat column type names into alchemy columns
 
         Returns
         -------

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -1,0 +1,284 @@
+"""Module responsible for L1DB schema operations.
+"""
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+import logging
+import os
+import sys
+import yaml
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+import sqlalchemy
+from sqlalchemy import (Column, Index, MetaData, PrimaryKeyConstraint,
+                        UniqueConstraint, Table)
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+_LOG = logging.getLogger(__name__)
+
+#---------------------
+#  Class definition --
+#---------------------
+
+
+class L1dbSchema(object):
+    """Class for management of L1DB schema.
+
+    Parameters
+    ----------
+    engine : `Engine`
+        SQLAlchemy engine instance
+    dia_object_index : `str`
+        Indexing mode for DiaObject table, see :py:mod:`l1db` module.
+    dia_object_nightly : `boolean`
+        If `True` then create per-night DiaObject table as well.
+    schema_file : `str`, optional
+        Name of the YAML schema file, by default look for
+        $L1DBPROTO_DIR/data/l1db-schema.yaml file.
+    extra_schema_file : str
+        Name of the YAML schema file fith extra column definitions, by
+        default look for $L1DBPROTO_DIR/data/l1db-schema-extra.yaml file.
+    """
+
+    def __init__(self, engine, dia_object_index, dia_object_nightly,
+                 schema_file=None, extra_schema_file=None):
+
+        self._engine = engine
+        self._dia_object_index = dia_object_index
+        self._dia_object_nightly = dia_object_nightly
+
+        self._metadata = MetaData(self._engine)
+        self._tables = {}
+
+        # read schema from yaml
+        if not schema_file:
+            schema_file = os.path.join(os.environ.get("L1DBPROTO_DIR"),
+                                       "data", "l1db-schema.yaml")
+        if not extra_schema_file:
+            extra_schema_file = os.path.join(os.environ.get("L1DBPROTO_DIR"),
+                                             "data", "l1db-schema-extra.yaml")
+        _LOG.debug("Reading schema file %s", schema_file)
+        with open(schema_file) as schema_stream:
+            tables = list(yaml.load_all(schema_stream))
+            # index it by table name
+            self._schemas = {table['table']: table for table in tables}
+        _LOG.debug("Read %d tables from schema", len(self._schemas))
+
+        _LOG.debug("Reading schema file %s", extra_schema_file)
+        with open(extra_schema_file) as schema_stream:
+            tables = list(yaml.load_all(schema_stream))
+            # index it by table name
+            self._schemas_extra = {table['table']: table for table in tables}
+
+    def makeSchema(self, drop=False, mysql_engine='InnoDB'):
+        """Create or re-create all tables.
+
+        Parameters
+        ----------
+        drop : boolean
+            If True then drop tables before creating new ones.
+        mysql_engine : `str`
+            MySQL engine type to use for new tables.
+        """
+        # map cat column types to alchemy
+        type_map = dict(DOUBLE=self._make_doube_type(),
+                        FLOAT=sqlalchemy.types.Float,
+                        DATETIME=sqlalchemy.types.TIMESTAMP,
+                        BIGINT=sqlalchemy.types.BigInteger,
+                        INTEGER=sqlalchemy.types.Integer,
+                        INT=sqlalchemy.types.Integer,
+                        TINYINT=sqlalchemy.types.Integer,
+                        BLOB=sqlalchemy.types.LargeBinary,
+                        CHAR=sqlalchemy.types.CHAR)
+
+        if self._dia_object_index == 'htm20_id_iov':
+            constraints = [PrimaryKeyConstraint('htmId20', 'diaObjectId', 'validityStart',
+                                                name='PK_DiaObject'),
+                           Index('IDX_DiaObject_diaObjectId', 'diaObjectId')]
+        else:
+            constraints = [PrimaryKeyConstraint('diaObjectId', 'validityStart', name='PK_DiaObject'),
+                           Index('IDX_DiaObject_validityStart', 'validityStart'),
+                           Index('IDX_DiaObject_htmId20', 'htmId20')]
+        table = Table('DiaObject', self._metadata,
+                      *(self._table_columns('DiaObject', type_map) + constraints),
+                      mysql_engine=mysql_engine)
+
+        if self._dia_object_nightly:
+            table = Table('DiaObjectNightly', self._metadata,
+                          *self._table_columns('DiaObject', type_map),
+                          mysql_engine=mysql_engine)
+
+        if self._dia_object_index == 'last_object_table':
+            constraints = [PrimaryKeyConstraint('htmId20', 'diaObjectId', name='PK_DiaObjectLast'),
+                           Index('IDX_DiaObjectLast_diaObjectId', 'diaObjectId')]
+            table = Table('DiaObjectLast', self._metadata,
+                          *(self._table_columns('DiaObject', type_map) + constraints),
+                          mysql_engine=mysql_engine)
+
+        # for all other tables use index definitions in schema
+        for table_name in ('DiaSource', 'SSObject', 'DiaForcedSource', 'DiaObject_To_Object_Match'):
+            table = Table(table_name, self._metadata,
+                          *(self._table_columns(table_name, type_map) +
+                            self._table_indices(table_name, type_map)),
+                          mysql_engine=mysql_engine)
+
+        # special table to track visits, only used by prototype
+        visits = Table('L1DbProtoVisits', self._metadata,
+                       Column('visitId', sqlalchemy.types.BigInteger, nullable=False),
+                       Column('visitTime', sqlalchemy.types.TIMESTAMP, nullable=False),
+                       PrimaryKeyConstraint('visitId', name='PK_L1DbProtoVisits'),
+                       Index('IDX_L1DbProtoVisits_visitTime', 'visitTime'),
+                       mysql_engine=mysql_engine)
+
+        # create all tables (optionally drop first)
+        if drop:
+            _LOG.info('dropping all tables')
+            self._metadata.drop_all()
+        _LOG.info('creating all tables')
+        self._metadata.create_all()
+
+    @property
+    def visits(self):
+        """Returns SQLAlchemy `Table` instance for L1DbProtoVisits table.
+        """
+        return self._table_schema('L1DbProtoVisits')
+
+    @property
+    def objects(self):
+        """Returns SQLAlchemy `Table` instance for DiaObject table.
+        """
+        return self._table_schema('DiaObject')
+
+    @property
+    def objects_last(self):
+        """Returns SQLAlchemy `Table` instance for DiaObjectLast table.
+        """
+        return self._table_schema('DiaObjectLast')
+
+    @property
+    def objects_nightly(self):
+        """Returns SQLAlchemy `Table` instance for DiaObjectNightly table.
+        """
+        return self._table_schema('DiaObjectNightly')
+
+    @property
+    def sources(self):
+        """Returns SQLAlchemy `Table` instance for DiaSource table.
+        """
+        return self._table_schema('DiaSource')
+
+    @property
+    def forcedSources(self):
+        """Returns SQLAlchemy `Table` instance for DiaForcedSource table.
+        """
+        return self._table_schema('DiaForcedSource')
+
+    def _table_columns(self, table_name, type_map):
+        """Return set of columns in a table
+
+        Parameters
+        ----------
+        table_name : `str`
+            Name of the table.
+        type_map : `dict`
+            Mapping of the cat column type names into alchemy columns
+
+        Returns
+        -------
+        List of `Column` objects.
+        """
+
+        table_schema = self._schemas[table_name]
+        pkey_columns = set()
+        for index in table_schema.get('indices', []):
+            if index['type'] == 'PRIMARY':
+                pkey_columns = set(index['columns'])
+                break
+
+        # columns in _EXTRA_COLUMS can override cat definitions, and I also want
+        # to preserve order of the original cat schema so it's a bit messy
+        columns = table_schema['columns']
+        if table_name in self._schemas_extra:
+            extra_columns = self._schemas_extra[table_name].get('columns', [])
+            extra_columns = {col['name']: col for col in extra_columns}
+            _LOG.debug("Extra columns for table %s: %s", table_name, extra_columns.keys())
+            columns = []
+            used = set()
+            for col in table_schema['columns']:
+                if col['name'] in extra_columns:
+                    columns.append(extra_columns.pop(col['name']))
+                else:
+                    columns.append(col)
+            columns += extra_columns.values()
+
+        # convert all column dicts into alchemy Columns
+        column_defs = []
+        for column in columns:
+            kwargs = dict(nullable=column['nullable'])
+            if column['name'] in pkey_columns:
+                kwargs.update(autoincrement=False)
+            ctype = type_map[column['type']]
+            column_defs.append(Column(column['name'], ctype, **kwargs))
+
+        return column_defs
+
+    def _table_indices(self, table_name, type_map):
+        """Return set of constraints/indices in a table
+
+        Parameters
+        ----------
+        table_name : `str`
+            Name of the table.
+        type_map : `dict`
+            Mapping of the cat column type names into alchemy columns
+
+        Returns
+        -------
+        List of index/constraint objects.
+        """
+
+        table_schema = self._schemas[table_name]
+
+        # convert all index dicts into alchemy Columns
+        index_defs = []
+        for index in table_schema['indices']:
+            if index['type'] == "INDEX":
+                index_defs.append(Index(index['name'], *index['columns']))
+            else:
+                kwargs = {}
+                if 'name' in index:
+                    kwargs['name'] = index['name']
+                if index['type'] == "PRIMARY":
+                    index_defs.append(PrimaryKeyConstraint(*index['columns'], **kwargs))
+                elif index['type'] == "UNIQUE":
+                    index_defs.append(UniqueConstraint(*index['columns'], **kwargs))
+
+        return index_defs
+
+    def _make_doube_type(self):
+        """
+        DOUBLE type is database-specific, select one based on dialect.
+        """
+        if self._engine.name == 'mysql':
+            from sqlalchemy.dialects.mysql import DOUBLE
+            return DOUBLE(asdecimal=False)
+        elif self._engine.name == 'postgresql':
+            from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
+            return DOUBLE_PRECISION
+        else:
+            raise TypeError('cannot determine DOUBLE type, unexpected dialect: ' + self._engine.name)
+
+    def _table_schema(self, name):
+        """ Lazy reading of table schema """
+        table = self._tables.get(name)
+        if table is None:
+            table = Table(name, self._metadata, autoload=True)
+            self._tables[name] = table
+            _LOG.debug("read table schema for %s: %s", name, table.c)
+        return table

--- a/ups/l1dbproto.table
+++ b/ups/l1dbproto.table
@@ -1,3 +1,4 @@
+setupRequired(afw)
 setupRequired(db)
 setupRequired(python)
 setupRequired(pyyaml)

--- a/ups/l1dbproto.table
+++ b/ups/l1dbproto.table
@@ -1,5 +1,6 @@
 setupRequired(db)
 setupRequired(python)
+setupRequired(pyyaml)
 setupRequired(scons)
 setupRequired(sconsUtils)
 setupRequired(sphgeom)


### PR DESCRIPTION
All methods that produced or used lists obf namedtuples now use or
produce afw.table catalogs. Re-factored schema generation based on YAML
config files instead of hard-coded stuff.

Some caveats:
- afw.table schema has to be compatible with cat schema, some column
  name remapping is possible but units are defined by cat schema and
  no conversion between afw and cat is implemented.
- tested so far with mysql only