### PR TITLE
Add support for sqlite backend (DM-13799)

### DIFF
--- a/cfg/l1db-sqlite.cfg
+++ b/cfg/l1db-sqlite.cfg
@@ -1,0 +1,39 @@
+#
+# Example config file for L1DB using sqlite backend
+#
+
+[database]
+# SQLAlchemy URL for connection
+url = sqlite:///l1dbproto.db
+isolation_level = READ_UNCOMMITTED
+
+[l1db]
+# DiaObject indexing options, possible values:
+#  - baseline: (default) PK = (object ID, validity)
+#  - htm20_id_iov:       PK = (htmId, object ID, validity)
+#  - last_object_table:  as baseline but use separate table
+#                        for last DiaObject version
+dia_object_index = last_object_table
+
+# if set to 1 then define special nightly non-indexed DiaObject table
+# which is merged with actual table every night
+dia_object_nightly = 0
+
+# if non-zero then do "upsert" for DiaObjects which could be more efficient
+object_last_replace = 1
+
+# if set to 0 then DiaSources are not read at all,
+# actual non-zero value is ignored for now (reads all sources)
+read_sources_months = 12
+
+# if set to 0 then DiaForcedSources are not read at all,
+# actual non-zero value is ignored for now (reads all sources)
+read_forced_sources_months = 12
+
+# set to 1 to read complete DiaObject record (all columns)
+read_full_objects = 0
+
+# how to select sources, possible values:
+#  - by-fov: selects Sources using FOV region using HTM index
+#  - by-oid: selects Sources using DiaObject ID
+source_select = by-oid

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -306,6 +306,23 @@ class L1dbSchema(object):
             cmap[afw_name] = column
         return cmap
 
+    def getColumnMap(self, table_name):
+        """Returns mapping of column names to Column definitions.
+
+        Parameters
+        ----------
+        table_name : `str`
+            One of known L1DB table names.
+
+        Returns
+        -------
+        `dict` with column names as keys and `ColumnDef` instances as
+        values.
+        """
+        table = self._schemas[table_name]
+        cmap = {column.name: column for column in table.columns}
+        return cmap
+
     def _buildSchemas(self, schema_file, extra_schema_file, afw_schemas):
         """Create schema definitions for all tables.
 
@@ -499,6 +516,10 @@ class L1dbSchema(object):
         elif self._engine.name == 'postgresql':
             from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
             return DOUBLE_PRECISION
+        elif self._engine.name == 'sqlite':
+            # all floats in sqlite are 8-byte
+            from sqlalchemy.dialects.sqlite import REAL
+            return REAL
         else:
             raise TypeError('cannot determine DOUBLE type, unexpected dialect: ' + self._engine.name)
 


### PR DESCRIPTION
Few small changes were needed in backend-specific code to support
sqlite. Re-implemented getDiaObjects() to use standard alchemy query
building mechanism, that works better with `datetime` conversion
compared to my dumb text-based query.