### PR TITLE
More generic pixelization support (DM-13861)

### DIFF
--- a/bin/ap_proto
+++ b/bin/ap_proto
@@ -81,6 +81,29 @@ def _visitTimes(start_time, interval_sec, count):
             count -= 1
         dt += delta
 
+
+def _htm_indices(region):
+    """Generate a set of HTM indices covering specified field of view.
+
+    Parameters
+    ----------
+    region: `sphgeom.Region`
+        Region that needs to be indexed
+
+    Returns
+    -------
+    Sequence of ranges, range is a tuple (minHtmID, maxHtmID).
+    """
+
+    _LOG.debug('region: %s', region)
+    pixelator = HtmPixelization(constants.HTM_LEVEL)
+    indices = pixelator.envelope(region, constants.HTM_MAX_RANGES)
+    for irange in indices.ranges():
+        _LOG.debug('range: %s %s', pixelator.toString(irange[0]),
+                   pixelator.toString(irange[1]))
+
+    return indices.ranges()
+
 # def _utc_seconds(dt):
 #     """Convert datetime to POSIX seconds
 #     """
@@ -117,8 +140,6 @@ class APProto(object):
                             help='Interval between visits in seconds, def: 45')
         parser.add_argument('-c', '--config', default="l1db.cfg", metavar='PATH',
                             help='Name of the database config file, def: l1db.cfg')
-        parser.add_argument('-e', '--explain', default=False, action='store_true',
-                            help='Run queries with EXPLAIN')
         parser.add_argument('-U', '--no-update', default=False, action='store_true',
                             help='DO not update database, only reading is performed.')
         parser.add_argument('--start-time', type=_timeParse, default=None,
@@ -309,9 +330,12 @@ class APProto(object):
 
         with timer.Timer(name+"Objects-read"):
 
+            # determine indices that we need
+            ranges = _htm_indices(region)
+
             # Retrieve DiaObjects (latest versions) from database for matching,
             # this will produce wider coverage so further filtering is needed
-            latest_objects = db.getDiaObjects(region, explain=self.args.explain)
+            latest_objects = db.getDiaObjects(ranges)
             _LOG.info(name+'database found %s objects', len(latest_objects))
 
             # filter database obects to a mask
@@ -334,10 +358,11 @@ class APProto(object):
 
         with timer.Timer(name+"Source-read"):
 
-            read_srcs = db.getDiaSources(region, latest_objects, explain=self.args.explain)
+            latest_objects_ids = [obj['id'] for obj in latest_objects]
+            read_srcs = db.getDiaSources(latest_objects_ids)
             _LOG.info(name+'database found %s sources', len(read_srcs))
 
-            read_srcs = db.getDiaForcedSources(latest_objects, explain=self.args.explain)
+            read_srcs = db.getDiaForcedSources(latest_objects_ids)
             _LOG.info(name+'database found %s forced sources', len(read_srcs))
 
         if not self.args.no_update:
@@ -347,17 +372,17 @@ class APProto(object):
                 # store new versions of objects
                 _LOG.info(name+'will store %d Objects', len(objects))
                 if objects:
-                    db.storeDiaObjects(objects, dt, explain=self.args.explain)
+                    db.storeDiaObjects(objects, dt)
 
                 # store all sources
                 _LOG.info(name+'will store %d Sources', len(srcs))
                 if srcs:
-                    db.storeDiaSources(srcs, explain=self.args.explain)
+                    db.storeDiaSources(srcs)
 
                 # store all forced sources
                 _LOG.info(name+'will store %d ForcedSources', len(fsrcs))
                 if fsrcs:
-                    db.storeDiaForcedSources(fsrcs, explain=self.args.explain)
+                    db.storeDiaForcedSources(fsrcs)
 
     def _filterDiaObjects(self, latest_objects, region):
         """Filter out objects from a catalog which are outside region.
@@ -401,7 +426,7 @@ class APProto(object):
         # schema.addField("validityStart", "L")
         # schema.addField("validityEnd", "L")
         # schema.addField("lastNonForcedSource", "L")
-        schema.addField("htmId20", "L", doc="HTM index")
+        schema.addField("indexer_id", "L", doc="HTM index")
 
         return schema
 
@@ -454,7 +479,7 @@ class APProto(object):
             # record.set("lastNonForcedSource", _utc_seconds(dt))
             record.set("coord_ra", ra)
             record.set("coord_dec", decl)
-            record.set("htmId20", index)
+            record.set("indexer_id", index)
 
         _LOG.info('found %s matching objects and %s transients/noise', len(catalog) - n_trans, n_trans)
 
@@ -492,7 +517,7 @@ class APProto(object):
             # record.set("lastNonForcedSource", obj['lastNonForcedSource'])
             record.set("coord_ra", obj["coord_ra"])
             record.set("coord_dec", obj["coord_dec"])
-            record.set("htmId20", obj["htmId20"])
+            record.set("indexer_id", obj["indexer_id"])
 
     def _makeDiaSourceSchema(self):
         """Make afw.table schema for DiaSource.
@@ -513,7 +538,7 @@ class APProto(object):
         schema.addField("ccdVisitId", "L")
         schema.addField("parent", "L")
         schema.addField("flags", "L")
-        schema.addField("htmId20", "L", doc="HTM index")
+        schema.addField("indexer_id", "L", doc="HTM index")
 
         return schema
 
@@ -561,7 +586,7 @@ class APProto(object):
             record.set("coord_ra", ra)
             record.set("coord_dec", decl)
             record.set("flags", 0)
-            record.set("htmId20", index)
+            record.set("indexer_id", index)
 
         return catalog
 

--- a/data/l1db-afw-map.yaml
+++ b/data/l1db-afw-map.yaml
@@ -2,12 +2,16 @@
 # names. Top-level structure is a dictionary indexed by table name and the
 # values are dictionaries where key is the name of column in L1DB and value
 # is the name of the column in afw.table
+
 DiaObject:
   diaObjectId: id
   ra: coord_ra
   decl: coord_dec
+  pixelId: indexer_id
+
 DiaSource:
   diaSourceId: id
   parentDiaSourceId: parent
   ra: coord_ra
   decl: coord_dec
+  pixelId: indexer_id

--- a/data/l1db-schema-extra.yaml
+++ b/data/l1db-schema-extra.yaml
@@ -1,8 +1,7 @@
-# Extra columns for L1DB schema that do not appear in cat schema but
-# are necessary for implementation purposes. Definitions in this file
-# override column definition in standard schema.
-# Special indices for DiaObject table re defined as special tables here
-# but have no columns.
+# Extra schema definitions compared to `cat` schema used by L1DB implementation.
+
+# DiaObject needs a special column for time of last seen DiaSource,
+# validityEnd should be allowed to have NULL (for +Infinity)
 table: DiaObject
 columns:
 - name: lastNonForcedSource
@@ -14,24 +13,29 @@ columns:
   nullable: true
   description: Time when validity of this diaObject ends.
   default: null
+
 ---
+# DiaObjectLast uses the same columns as DiaObject but has different index
 table: DiaObjectLast
 indices:
 - name: PK_DiaObjectLast
   columns:
-  - htmId20
+  - pixelId
   - diaObjectId
   type: PRIMARY
 - name: IDX_DiaObjectLast_diaObjectId
   columns:
   - diaObjectId
   type: INDEX
+
 ---
+# Special PK index for DiaObject table with spacial column being first
+# (should provide better locality)
 table: DiaObjectIndexHtmFirst
 indices:
 - name: PK_DiaObject
   columns:
-  - htmId20
+  - pixelId
   - diaObjectId
   - validityStart
   type: PRIMARY

--- a/data/l1db-schema.yaml
+++ b/data/l1db-schema.yaml
@@ -501,7 +501,7 @@ columns:
   default: '0'
   description: Flags, bitwise OR tbd.
   ucd: meta.code
-- name: htmId20
+- name: pixelId
   type: BIGINT
   nullable: false
   description: HTM index.
@@ -517,7 +517,7 @@ indices:
   type: INDEX
 - name: IDX_DiaObject_htmId20
   columns:
-  - htmId20
+  - pixelId
   type: INDEX
 ---
 table: SSObject
@@ -1548,7 +1548,7 @@ columns:
   default: '0'
   description: Flags, bitwise OR tbd.
   ucd: meta.code
-- name: htmId20
+- name: pixelId
   type: BIGINT
   nullable: false
   description: HTM index.
@@ -1571,7 +1571,7 @@ indices:
   type: INDEX
 - name: IDX_DiaSource_htmId20
   columns:
-  - htmId20
+  - pixelId
   type: INDEX
 ---
 table: DiaForcedSource


### PR DESCRIPTION
Renamed htmId20 column in schema definition. L1db does not do region
pixelization itself and expects client to perform all spacial indexing
stuff. API changed to be more generic w.r.t. pixelization handling.