### PR TITLE
DM-14333: Support Oracle dialect in AP prototype script

### DIFF
--- a/data/l1db-schema.yaml
+++ b/data/l1db-schema.yaml
@@ -1654,11 +1654,11 @@ columns:
   description: Natural log of the probability that the observed diaObject is the same
     as the nearby object.
 indices:
-- name: IDX_DiaObjectToObjectMatch_diaObjectId
+- name: IDX_DiaO2OMatch_diaObjectId
   columns:
   - diaObjectId
   type: INDEX
-- name: IDX_DiaObjectToObjectMatch_objectId
+- name: IDX_DiaO2OMatch_objectId
   columns:
   - objectId
   type: INDEX

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -503,6 +503,9 @@ class L1dbSchema(object):
         elif self._engine.name == 'postgresql':
             from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
             return DOUBLE_PRECISION
+        elif self._engine.name == 'oracle':
+            from sqlalchemy.dialects.oracle import DOUBLE_PRECISION
+            return DOUBLE_PRECISION
         elif self._engine.name == 'sqlite':
             # all floats in sqlite are 8-byte
             from sqlalchemy.dialects.sqlite import REAL


### PR DESCRIPTION
Summary of changes:
- With cx_Oracle most efficient way to INSERT is with multiparams
- UPSERT is implemented via Oracle MERGE statement with subquery from DUAL, again with multiparam
- Oracle has 1000 item limit for IN(), has to split long list of IDs into 1000-sized chunks
- Index names have to be shorter than 30 characters