### PR TITLE
DM-14712: Improve Oracle support

### DIFF
--- a/bin/create_l1_schema
+++ b/bin/create_l1_schema
@@ -50,6 +50,8 @@ def main():
                         'all data in the tables, use with extreme caution')
     parser.add_argument('-c', '--config', default=None, metavar='PATH',
                         help='Name of the database config file (pex.config)')
+    parser.add_argument('-t', '--tablespace', default=None, metavar='TABLESPACE',
+                        help='Name of the Oracle tablespace for new tables.')
     parser.add_argument('-a', '--association', default=False,
                         action='store_true',
                         help='Use afw.table schema from ap_association')
@@ -71,7 +73,7 @@ def main():
     db = l1db.L1db(config=config, afw_schemas=afw_schemas)
 
     # do it
-    db.makeSchema(drop=args.drop)
+    db.makeSchema(drop=args.drop, oracle_tablespace=args.tablespace)
 
 
 #

--- a/bin/create_l1_schema
+++ b/bin/create_l1_schema
@@ -52,6 +52,9 @@ def main():
                         help='Name of the database config file (pex.config)')
     parser.add_argument('-t', '--tablespace', default=None, metavar='TABLESPACE',
                         help='Name of the Oracle tablespace for new tables.')
+    parser.add_argument('-i', '--iot', default=False,
+                        action='store_true',
+                        help='Make index-organized DiaObjectLast table.')
     parser.add_argument('-a', '--association', default=False,
                         action='store_true',
                         help='Use afw.table schema from ap_association')
@@ -73,7 +76,7 @@ def main():
     db = l1db.L1db(config=config, afw_schemas=afw_schemas)
 
     # do it
-    db.makeSchema(drop=args.drop, oracle_tablespace=args.tablespace)
+    db.makeSchema(drop=args.drop, oracle_tablespace=args.tablespace, oracle_iot=args.iot)
 
 
 #

--- a/bin/log2csv
+++ b/bin/log2csv
@@ -11,6 +11,7 @@ from __future__ import print_function
 #--------------------------------
 from argparse import ArgumentParser
 from collections import defaultdict
+import gzip
 import logging
 import sys
 
@@ -84,11 +85,12 @@ def _parse_counts(line):
     """
     words = line.split()
     count = int(words[-1])
-    if "DiaObject" in words:
+    table_name = words[-4]
+    if table_name.endswith("DiaObject"):
         _values['obj_count'] += count
-    elif "DiaSource" in words:
+    elif table_name.endswith("DiaSource"):
         _values['src_count'] += count
-    elif "DiaForcedSource" in words:
+    elif table_name.endswith("DiaForcedSource"):
         _values['fsrc_count'] += count
 
 
@@ -102,40 +104,40 @@ def _parse_timers(line):
     words = line.replace('=', ' ').split()
     real = float(words[-5])
     cpu = float(words[-3]) + float(words[-1])
-    if " DiaObject select: " in line:
+    if "DiaObject select: " in line:
         _values['obj_select_real'] += real
         _values['obj_select_cpu'] += cpu
         _values['select_real'] += real
-    elif " DiaObject truncate: " in line:
+    elif "DiaObject truncate: " in line:
         _values['obj_trunc_real'] += real
         _values['obj_trunc_cpu'] += cpu
-    elif " DiaObjectLast delete: " in line:
+    elif "DiaObjectLast delete: " in line:
         _values['obj_last_delete_real'] += real
         _values['obj_last_delete_cpu'] += cpu
-    elif " DiaObject insert: " in line or " DiaObjectNightly insert: " in line:
+    elif "DiaObject insert: " in line or " DiaObjectNightly insert: " in line:
         _values['obj_insert_real'] += real
         _values['obj_insert_cpu'] += cpu
-    elif " DiaObjectLast insert: " in line:
+    elif "DiaObjectLast insert: " in line:
         _values['obj_last_insert_real'] += real
         _values['obj_last_insert_cpu'] += cpu
-    elif " DiaObjectNightly copy: " in line:
+    elif "DiaObjectNightly copy: " in line:
         _values['obj_daily_copy_real'] += real
         _values['obj_daily_copy_cpu'] += cpu
-    elif " DiaObjectNightly delete: " in line:
+    elif "DiaObjectNightly delete: " in line:
         _values['obj_daily_delete_real'] += real
         _values['obj_daily_delete_cpu'] += cpu
-    elif " DiaSource select: " in line:
+    elif "DiaSource select: " in line:
         _values['src_select_real'] += real
         _values['src_select_cpu'] += cpu
         _values['select_real'] += real
-    elif " DiaSource insert: " in line:
+    elif "DiaSource insert: " in line:
         _values['src_insert_real'] += real
         _values['src_insert_cpu'] += cpu
-    elif " DiaForcedSource select: " in line:
+    elif "DiaForcedSource select: " in line:
         _values['fsrc_select_real'] += real
         _values['fsrc_select_cpu'] += cpu
         _values['select_real'] += real
-    elif " DiaForcedSource insert: " in line:
+    elif "DiaForcedSource insert: " in line:
         _values['fsrc_insert_real'] += real
         _values['fsrc_insert_cpu'] += cpu
     elif " L1-store: " in line:
@@ -225,7 +227,7 @@ def main():
                         help='Save fewer columns into CSV file.')
     parser.add_argument('-d', '--daily', action='store_true', default=False,
                         help='Extract numbers from daily activities.')
-    parser.add_argument('file', help='Name of input log file', nargs='+')
+    parser.add_argument('file', help='Name of input log file, optionally compressed, use "-" for stdin', nargs='+')
     args = parser.parse_args()
 
     # configure logging
@@ -247,7 +249,17 @@ def main():
 
     # open each file in order
     for input in args.file:
-        for line in open(input):
+        if input == '-':
+            input = sys.stdin
+        else:
+            f = gzip.open(input, "rt")
+            try:
+                f.read(1)
+                f.seek(0)
+                input = f
+            except OSError:
+                input = open(input, "rt")
+        for line in input:
             for match, method in dispatch:
                 # if line matches then call corresponding method
                 if match in line:

--- a/bin/log2csv
+++ b/bin/log2csv
@@ -35,8 +35,8 @@ def _configLogger(verbosity):
 class _Stat:
 
     def __init__(self, cnt=0, sum=0.):
-        self._cnt = 0
-        self._sum = 0
+        self._cnt = cnt
+        self._sum = sum
 
     def value(self):
         if self._cnt == 0:
@@ -107,7 +107,6 @@ def _parse_timers(line):
     if "DiaObject select: " in line:
         _values['obj_select_real'] += real
         _values['obj_select_cpu'] += cpu
-        _values['select_real'] += real
     elif "DiaObject truncate: " in line:
         _values['obj_trunc_real'] += real
         _values['obj_trunc_cpu'] += cpu
@@ -129,14 +128,12 @@ def _parse_timers(line):
     elif "DiaSource select: " in line:
         _values['src_select_real'] += real
         _values['src_select_cpu'] += cpu
-        _values['select_real'] += real
     elif "DiaSource insert: " in line:
         _values['src_insert_real'] += real
         _values['src_insert_cpu'] += cpu
     elif "DiaForcedSource select: " in line:
         _values['fsrc_select_real'] += real
         _values['fsrc_select_cpu'] += cpu
-        _values['select_real'] += real
     elif "DiaForcedSource insert: " in line:
         _values['fsrc_insert_real'] += real
         _values['fsrc_insert_cpu'] += cpu
@@ -184,6 +181,21 @@ _cols = ['visit',
          'obj_in_fov',
          'obj_count', 'src_count', 'fsrc_count']
 
+
+def _value(key):
+    """Return value for given key, special handling for some
+    computed values.
+    """
+    if key == "select_real":
+        sumkeys = ("obj_select_real", "src_select_real", "fsrc_select_real")
+        values = [_values[sk].value() for sk in sumkeys]
+        values = [value for value in values if value is not None]
+        if values:
+            return _Stat(1, sum(values))
+        else:
+            return _Stat()
+    return _values[key]
+
 # Flag to print CSV header line once
 _header = True
 
@@ -196,7 +208,7 @@ def _end_visit(line):
     if _header:
         print(','.join(_cols))
         _header = False
-    print(','.join(str(_values[c]) for c in _cols))
+    print(','.join(str(_value(c)) for c in _cols))
 
 # Map line sibstring to method
 _dispatch = [("Start processing visit", _new_visit),

--- a/data/l1db-afw-map.yaml
+++ b/data/l1db-afw-map.yaml
@@ -9,6 +9,12 @@ DiaObject:
   decl: coord_dec
   pixelId: pixelId
 
+DiaObjectLast:
+  diaObjectId: id
+  ra: coord_ra
+  decl: coord_dec
+  pixelId: indexer_id
+
 DiaSource:
   diaSourceId: id
   parentDiaSourceId: parent

--- a/data/l1db-schema-extra-oracle.yaml
+++ b/data/l1db-schema-extra-oracle.yaml
@@ -1,0 +1,78 @@
+# Extra schema definitions compared to `cat` schema used by L1DB implementation.
+# This is a variant of l1db-schema-extra.yaml which is Oracle-specific,
+# DaiObjectLast PK includes all columns from SELECT (check dia_object_columns
+# config parameter)
+
+# DiaObject needs a special column for time of last seen DiaSource,
+# validityEnd should be allowed to have NULL (for +Infinity)
+table: DiaObject
+columns:
+- name: lastNonForcedSource
+  type: DATETIME
+  nullable: false
+  description: Last time when non-forced DIASource was seen for this object.
+- name: validityEnd
+  type: DATETIME
+  nullable: true
+  description: Time when validity of this diaObject ends.
+  default: null
+
+---
+# DiaObjectLast uses the same columns as DiaObject but has different index
+table: DiaObjectLast
+indices:
+- name: PK_DiaObjectLast
+  columns:
+  - pixelId
+  - diaObjectId
+  - lastNonForcedSource
+  - ra
+  - decl
+  - raSigma
+  - declSigma
+  - ra_decl_Cov
+  - radecTai
+  - pmRa
+  - pmRaSigma
+  - pmDecl
+  - pmDeclSigma
+  - parallax
+  - parallaxSigma
+  - pmRa_pmDecl_Cov
+  - pmRa_parallax_Cov
+  - pmDecl_parallax_Cov
+  - pmParallaxChi2
+  - pmParallaxNdata
+  - uPSFluxMean
+  - uFPFluxMean
+  - gPSFluxMean
+  - gFPFluxMean
+  - rPSFluxMean
+  - rFPFluxMean
+  - iPSFluxMean
+  - iFPFluxMean
+  - zPSFluxMean
+  - zFPFluxMean
+  - yPSFluxMean
+  - yFPFluxMean
+  type: PRIMARY
+- name: IDX_DiaObjLast_diaObjId
+  columns:
+  - diaObjectId
+  type: INDEX
+
+---
+# Special PK index for DiaObject table with spacial column being first
+# (should provide better locality)
+table: DiaObjectIndexHtmFirst
+indices:
+- name: PK_DiaObject
+  columns:
+  - pixelId
+  - diaObjectId
+  - validityStart
+  type: PRIMARY
+- name: IDX_DiaObject_diaObjId
+  columns:
+  - diaObjectId
+  type: INDEX

--- a/data/l1db-schema-extra.yaml
+++ b/data/l1db-schema-extra.yaml
@@ -15,8 +15,110 @@ columns:
   default: null
 
 ---
-# DiaObjectLast uses the same columns as DiaObject but has different index
+# DiaObjectLast uses subset of columns from DiaObject and different index
 table: DiaObjectLast
+columns:
+- name: diaObjectId
+  type: BIGINT
+  nullable: false
+  description: Unique id.
+  ucd: meta.id;src
+- name: lastNonForcedSource
+  type: DATETIME
+  nullable: false
+  description: Last time when non-forced DIASource was seen for this object.
+- name: ra
+  type: DOUBLE
+  nullable: false
+  description: RA-coordinate of the position of the object at time radecTai.
+  ucd: pos.eq.ra
+  unit: deg
+- name: raSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of ra.
+  ucd: stat.error;pos.eq.ra
+  unit: deg
+- name: decl
+  type: DOUBLE
+  nullable: false
+  description: Decl-coordinate of the position of the object at time radecTai.
+  ucd: pos.eq.dec
+  unit: deg
+- name: declSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of decl.
+  ucd: stat.error;pos.eq.dec
+  unit: deg
+- name: ra_decl_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance between ra and decl.
+  unit: deg^2
+- name: radecTai
+  type: DOUBLE
+  nullable: false
+  description: Time at which the object was at a position ra/decl.
+  ucd: time.epoch
+- name: pmRa
+  type: FLOAT
+  nullable: false
+  description: Proper motion (ra).
+  ucd: pos.pm
+  unit: mas/yr
+- name: pmRaSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of pmRa.
+  ucd: stat.error;pos.pm
+  unit: mas/yr
+- name: pmDecl
+  type: FLOAT
+  nullable: false
+  description: Proper motion (decl).
+  ucd: pos.pm
+  unit: mas/yr
+- name: pmDeclSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of pmDecl.
+  ucd: stat.error;pos.pm
+  unit: mas/yr
+- name: parallax
+  type: FLOAT
+  nullable: false
+  description: Parallax.
+  ucd: pos.parallax
+  unit: mas
+- name: parallaxSigma
+  type: FLOAT
+  nullable: false
+  description: Uncertainty of parallax.
+  ucd: stat.error;pos.parallax
+  unit: mas
+- name: pmRa_pmDecl_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance of pmRa and pmDecl.
+  ucd: stat.covariance;pos.eq
+  unit: (mas/yr)^2
+- name: pmRa_parallax_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance of pmRa and parallax.
+  ucd: stat.covariance
+  unit: mas^2/yr
+- name: pmDecl_parallax_Cov
+  type: FLOAT
+  nullable: false
+  description: Covariance of pmDecl and parallax.
+  ucd: stat.covariance
+  unit: mas^2/yr
+- name: pixelId
+  type: BIGINT
+  nullable: false
+  description: HTM index.
 indices:
 - name: PK_DiaObjectLast
   columns:

--- a/data/l1db-schema-extra.yaml
+++ b/data/l1db-schema-extra.yaml
@@ -23,7 +23,7 @@ indices:
   - pixelId
   - diaObjectId
   type: PRIMARY
-- name: IDX_DiaObjectLast_diaObjectId
+- name: IDX_DiaObjLast_diaObjId
   columns:
   - diaObjectId
   type: INDEX
@@ -39,7 +39,7 @@ indices:
   - diaObjectId
   - validityStart
   type: PRIMARY
-- name: IDX_DiaObject_diaObjectId
+- name: IDX_DiaObject_diaObjId
   columns:
   - diaObjectId
   type: INDEX

--- a/data/l1db-schema.yaml
+++ b/data/l1db-schema.yaml
@@ -511,7 +511,7 @@ indices:
   - diaObjectId
   - validityStart
   type: PRIMARY
-- name: IDX_DiaObject_validityStart
+- name: IDX_DiaObject_valStart
   columns:
   - validityStart
   type: INDEX
@@ -1561,11 +1561,11 @@ indices:
   columns:
   - ccdVisitId
   type: INDEX
-- name: IDX_DiaSource_diaObjectId
+- name: IDX_DiaSource_diaObjId
   columns:
   - diaObjectId
   type: INDEX
-- name: IDX_DiaSource_ssObjectId
+- name: IDX_DiaSource_ssObjId
   columns:
   - ssObjectId
   type: INDEX
@@ -1625,7 +1625,7 @@ indices:
   - diaObjectId
   - ccdVisitId
   type: PRIMARY
-- name: IDX_DiaForcedSource_ccdVisitId
+- name: IDX_DiaFSource_ccdVisitId
   columns:
   - ccdVisitId
   type: INDEX
@@ -1654,7 +1654,7 @@ columns:
   description: Natural log of the probability that the observed diaObject is the same
     as the nearby object.
 indices:
-- name: IDX_DiaO2OMatch_diaObjectId
+- name: IDX_DiaO2OMatch_diaObjId
   columns:
   - diaObjectId
   type: INDEX

--- a/python/lsst/l1dbproto/l1db.py
+++ b/python/lsst/l1dbproto/l1db.py
@@ -168,6 +168,9 @@ class L1dbConfig(pexConfig.Config):
     timer = Field(dtype=bool,
                   doc="If True then print/log timing information",
                   default=False)
+    diaobject_index_hint = Field(dtype=str,
+                                 doc="Name of the index to use with Oracle index hint",
+                                 default=None)
 
 
 class L1db(object):
@@ -329,6 +332,9 @@ class L1db(object):
         else:
             columns = [table.c[col] for col in self.config.dia_object_columns]
             query = sql.select(columns)
+
+        if self.config.diaobject_index_hint:
+            query = query.with_hint(table, 'index_rs_asc(%(name)s "{}")'.format(self.config.diaobject_index_hint))
 
         # build selection
         exprlist = []

--- a/python/lsst/l1dbproto/l1db.py
+++ b/python/lsst/l1dbproto/l1db.py
@@ -677,7 +677,7 @@ class L1db(object):
             cursor = connection.cursor()
             cursor.execute("VACUUM ANALYSE")
 
-    def makeSchema(self, drop=False, mysql_engine='InnoDB', oracle_tablespace=None):
+    def makeSchema(self, drop=False, mysql_engine='InnoDB', oracle_tablespace=None, oracle_iot=False):
         """Create or re-create all tables.
 
         Parameters
@@ -686,8 +686,12 @@ class L1db(object):
             If True then drop tables before creating new ones.
         mysql_engine : `str`, optional
             Name of the MySQL engine to use for new tables.
+        oracle_iot : `bool`, optional
+            Make Index-organized DiaObjectLast table.
         """
-        self._schema.makeSchema(drop=drop, mysql_engine=mysql_engine, oracle_tablespace=oracle_tablespace)
+        self._schema.makeSchema(drop=drop, mysql_engine=mysql_engine,
+                                oracle_tablespace=oracle_tablespace,
+                                oracle_iot=oracle_iot)
 
     def _explain(self, query, conn):
         """Run the query with explain

--- a/python/lsst/l1dbproto/l1db.py
+++ b/python/lsst/l1dbproto/l1db.py
@@ -171,6 +171,12 @@ class L1dbConfig(pexConfig.Config):
     diaobject_index_hint = Field(dtype=str,
                                  doc="Name of the index to use with Oracle index hint",
                                  default=None)
+    dynamic_sampling_hint = Field(dtype=int,
+                                  doc="If non-zero then use dynamic_sampling hint",
+                                  default=0)
+    cardinality_hint = Field(dtype=int,
+                             doc="If non-zero then use cardinality hint",
+                             default=0)
 
 
 class L1db(object):
@@ -335,6 +341,10 @@ class L1db(object):
 
         if self.config.diaobject_index_hint:
             query = query.with_hint(table, 'index_rs_asc(%(name)s "{}")'.format(self.config.diaobject_index_hint))
+        if self.config.dynamic_sampling_hint > 0:
+            query = query.with_hint(table, 'dynamic_sampling(%(name)s {})'.format(self.config.dynamic_sampling_hint))
+        if self.config.cardinality_hint > 0:
+            query = query.with_hint(table, 'FIRST_ROWS_1 cardinality(%(name)s {})'.format(self.config.cardinality_hint))
 
         # build selection
         exprlist = []

--- a/python/lsst/l1dbproto/l1db.py
+++ b/python/lsst/l1dbproto/l1db.py
@@ -563,9 +563,8 @@ class L1db(object):
                         res = conn.execute(sql.text(query))
                     _LOG.debug("deleted %s objects", res.rowcount)
 
-                extra_columns = dict(lastNonForcedSource=dt, validityStart=dt,
-                                     validityEnd=None)
-                self._storeObjectsAfw(objs, conn, table, "DiaObject",
+                extra_columns = dict(lastNonForcedSource=dt)
+                self._storeObjectsAfw(objs, conn, table, "DiaObjectLast",
                                       replace=do_replace,
                                       extra_columns=extra_columns)
 

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -95,9 +95,12 @@ def make_minimal_dia_source_schema():
 def _add_suffixes(element, compiler, **kw):
     """Add all needed suffixed for Oracle CREATE TABLE statement"""
     text = compiler.visit_create_table(element, **kw)
+    _LOG.debug("text: %r", text)
     oracle_tablespace = element.element.info.get("oracle_tablespace")
+    _LOG.debug("oracle_tablespace: %r", oracle_tablespace)
     if oracle_tablespace:
         text += " TABLESPACE " + oracle_tablespace
+    _LOG.debug("text: %r", text)
     return text
 
 
@@ -105,9 +108,12 @@ def _add_suffixes(element, compiler, **kw):
 def _add_suffixes(element, compiler, **kw):
     """Add all needed suffixed for Oracle CREATE INDEX statement"""
     text = compiler.visit_create_index(element, **kw)
+    _LOG.debug("text: %r", text)
     oracle_tablespace = element.element.info.get("oracle_tablespace")
+    _LOG.debug("oracle_tablespace: %r", oracle_tablespace)
     if oracle_tablespace:
         text += " TABLESPACE " + oracle_tablespace
+    _LOG.debug("text: %r", text)
     return text
 
 #---------------------
@@ -296,7 +302,10 @@ class L1dbSchema(object):
         """
 
         # re-make table schema for all needed tables with possibly different options
+        _LOG.debug("clear metadata")
         self._metadata.clear()
+        _LOG.debug("re-do schema mysql_engine=%r oracle_tablespace=%r",
+                   mysql_engine, oracle_tablespace)
         self._makeTables(mysql_engine=mysql_engine, oracle_tablespace=oracle_tablespace)
 
         # create all tables (optionally drop first)

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -14,6 +14,8 @@ import yaml
 import sqlalchemy
 from sqlalchemy import (Column, Index, MetaData, PrimaryKeyConstraint,
                         UniqueConstraint, Table)
+from sqlalchemy.schema import CreateTable, CreateIndex
+from sqlalchemy.ext.compiler import compiles
 import lsst.afw.table as afwTable
 
 #----------------------------------
@@ -89,6 +91,24 @@ def make_minimal_dia_source_schema():
     return schema
 
 
+@compiles(CreateTable, "oracle")
+def _add_suffixes(element, compiler, **kw):
+    """Add all needed suffixed for Oracle CREATE TABLE statement"""
+    text = compiler.visit_create_table(element, **kw)
+    oracle_tablespace = element.element.info.get("oracle_tablespace")
+    if oracle_tablespace:
+        text += " TABLESPACE " + oracle_tablespace
+    return text
+
+
+@compiles(CreateIndex, "oracle")
+def _add_suffixes(element, compiler, **kw):
+    """Add all needed suffixed for Oracle CREATE INDEX statement"""
+    text = compiler.visit_create_index(element, **kw)
+    oracle_tablespace = element.element.info.get("oracle_tablespace")
+    if oracle_tablespace:
+        text += " TABLESPACE " + oracle_tablespace
+    return text
 
 #---------------------
 #  Class definition --
@@ -119,6 +139,8 @@ class L1dbSchema(object):
         Dictionary with table name for a key and `afw.table.Schema`
         for a value. Columns in schema will be added to standard L1DB
         schema (only if standard schema does not have matching column).
+    prefix : `str`, optional
+        Prefix to add to all scheam elements.
     """
 
     # map afw type names into cat type names
@@ -137,11 +159,12 @@ class L1dbSchema(object):
 
     def __init__(self, engine, dia_object_index, dia_object_nightly,
                  schema_file=None, extra_schema_file=None, column_map=None,
-                 afw_schemas=None):
+                 afw_schemas=None, prefix=""):
 
         self._engine = engine
         self._dia_object_index = dia_object_index
         self._dia_object_nightly = dia_object_nightly
+        self._prefix = prefix
 
         self._metadata = MetaData(self._engine)
         self._tables = {}
@@ -172,7 +195,7 @@ class L1dbSchema(object):
                               BLOB=sqlalchemy.types.LargeBinary,
                               CHAR=sqlalchemy.types.CHAR)
 
-    def makeSchema(self, drop=False, mysql_engine='InnoDB'):
+    def makeSchema(self, drop=False, mysql_engine='InnoDB', oracle_tablespace=None):
         """Create or re-create all tables.
 
         Parameters
@@ -183,42 +206,49 @@ class L1dbSchema(object):
             MySQL engine type to use for new tables.
         """
 
+        info = dict(oracle_tablespace=oracle_tablespace)
+
         if self._dia_object_index == 'pix_id_iov':
             # Special PK with HTM column in first position
-            constraints = self._tableIndices('DiaObjectIndexHtmFirst')
+            constraints = self._tableIndices('DiaObjectIndexHtmFirst', info)
         else:
-            constraints = self._tableIndices('DiaObject')
-        Table('DiaObject', self._metadata,
+            constraints = self._tableIndices('DiaObject', info)
+        Table(self._prefix+'DiaObject', self._metadata,
               *(self._tableColumns('DiaObject') + constraints),
-              mysql_engine=mysql_engine)
+              mysql_engine=mysql_engine,
+              info=info)
 
         if self._dia_object_nightly:
             # Same as DiaObject but no index
-            Table('DiaObjectNightly', self._metadata,
+            Table(self._prefix+'DiaObjectNightly', self._metadata,
                   *self._tableColumns('DiaObject'),
-                  mysql_engine=mysql_engine)
+                  mysql_engine=mysql_engine,
+                  info=info)
 
         if self._dia_object_index == 'last_object_table':
             # Same as DiaObject but with special index
-            Table('DiaObjectLast', self._metadata,
+            Table(self._prefix+'DiaObjectLast', self._metadata,
                   *(self._tableColumns('DiaObject') +
-                    self._tableIndices('DiaObjectLast')),
-                  mysql_engine=mysql_engine)
+                    self._tableIndices('DiaObjectLast', info)),
+                  mysql_engine=mysql_engine,
+                  info=info)
 
         # for all other tables use index definitions in schema
         for table_name in ('DiaSource', 'SSObject', 'DiaForcedSource', 'DiaObject_To_Object_Match'):
-            Table(table_name, self._metadata,
+            Table(self._prefix+table_name, self._metadata,
                   *(self._tableColumns(table_name) +
-                    self._tableIndices(table_name)),
-                  mysql_engine=mysql_engine)
+                    self._tableIndices(table_name, info)),
+                  mysql_engine=mysql_engine,
+                  info=info)
 
         # special table to track visits, only used by prototype
-        Table('L1DbProtoVisits', self._metadata,
+        Table(self._prefix+'L1DbProtoVisits', self._metadata,
               Column('visitId', sqlalchemy.types.BigInteger, nullable=False),
               Column('visitTime', sqlalchemy.types.TIMESTAMP, nullable=False),
-              PrimaryKeyConstraint('visitId', name='PK_L1DbProtoVisits'),
-              Index('IDX_L1DbProtoVisits_visitTime', 'visitTime'),
-              mysql_engine=mysql_engine)
+              PrimaryKeyConstraint('visitId', name=self._prefix+'PK_L1DbProtoVisits'),
+              Index(self._prefix+'IDX_L1DbProtoVisits_vTime', 'visitTime', info=info),
+              mysql_engine=mysql_engine,
+              info=info)
 
         # create all tables (optionally drop first)
         if drop:
@@ -522,7 +552,7 @@ class L1dbSchema(object):
         ctype = self._afw_type_map[field.getTypeString()]
         return dict(name=column, type=ctype, nullable=True)
 
-    def _tableIndices(self, table_name):
+    def _tableIndices(self, table_name, info):
         """Return set of constraints/indices in a table
 
         Parameters
@@ -541,11 +571,11 @@ class L1dbSchema(object):
         index_defs = []
         for index in table_schema.indices:
             if index.type == "INDEX":
-                index_defs.append(Index(index.name, *index.columns))
+                index_defs.append(Index(self._prefix+index.name, *index.columns, info=info))
             else:
                 kwargs = {}
                 if index.name:
-                    kwargs['name'] = index.name
+                    kwargs['name'] = self._prefix+index.name
                 if index.type == "PRIMARY":
                     index_defs.append(PrimaryKeyConstraint(*index.columns, **kwargs))
                 elif index.type == "UNIQUE":
@@ -589,7 +619,7 @@ class L1dbSchema(object):
         """
         table = self._tables.get(name)
         if table is None:
-            table = Table(name, self._metadata, autoload=True)
+            table = Table(self._prefix+name, self._metadata, autoload=True)
             self._tables[name] = table
             _LOG.debug("read table schema for %s: %s", name, table.c)
         return table

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -267,7 +267,7 @@ class L1dbSchema(object):
             info2 = info.copy()
             info2.update(oracle_iot=oracle_iot)
             table = Table(self._prefix+'DiaObjectLast', self._metadata,
-                          *(self._tableColumns('DiaObject') +
+                          *(self._tableColumns('DiaObjectLast') +
                             self._tableIndices('DiaObjectLast', info)),
                           mysql_engine=mysql_engine,
                           info=info2)

--- a/python/lsst/l1dbproto/l1dbschema.py
+++ b/python/lsst/l1dbproto/l1dbschema.py
@@ -118,6 +118,21 @@ def _add_suffixes(element, compiler, **kw):
 class L1dbSchema(object):
     """Class for management of L1DB schema.
 
+    Attributes
+    ----------
+    objects : `sqlalchemy.Table`
+        DiaObject table instance
+    objects_nightly : `sqlalchemy.Table`
+        DiaObjectNightly table instance, may be None
+    objects_last : `sqlalchemy.Table`
+        DiaObjectLast table instance, may be None
+    sources : `sqlalchemy.Table`
+        DiaSource table instance
+    forcedSources : `sqlalchemy.Table`
+        DiaForcedSource table instance
+    visits : `sqlalchemy.Table`
+        L1DbProtoVisits table instance
+
     Parameters
     ----------
     engine : `Engine`
@@ -167,7 +182,13 @@ class L1dbSchema(object):
         self._prefix = prefix
 
         self._metadata = MetaData(self._engine)
-        self._tables = {}
+
+        self.objects = None
+        self.objects_nightly = None
+        self.objects_last = None
+        self.sources = None
+        self.forcedSources = None
+        self.visits = None
 
         _LOG.debug("Reading column map file %s", column_map)
         with open(column_map) as yaml_stream:
@@ -195,15 +216,18 @@ class L1dbSchema(object):
                               BLOB=sqlalchemy.types.LargeBinary,
                               CHAR=sqlalchemy.types.CHAR)
 
-    def makeSchema(self, drop=False, mysql_engine='InnoDB', oracle_tablespace=None):
-        """Create or re-create all tables.
+        # generate schema for all tables, must be called last
+        self._makeTables()
+
+    def _makeTables(self, mysql_engine='InnoDB', oracle_tablespace=None):
+        """Generate schema for all tables.
 
         Parameters
         ----------
-        drop : boolean
-            If True then drop tables before creating new ones.
-        mysql_engine : `str`
+        mysql_engine : `str`, optional
             MySQL engine type to use for new tables.
+        oracle_tablespace : `str`, optional
+            Name of Oracle tablespace, only useful with oracle
         """
 
         info = dict(oracle_tablespace=oracle_tablespace)
@@ -213,42 +237,67 @@ class L1dbSchema(object):
             constraints = self._tableIndices('DiaObjectIndexHtmFirst', info)
         else:
             constraints = self._tableIndices('DiaObject', info)
-        Table(self._prefix+'DiaObject', self._metadata,
-              *(self._tableColumns('DiaObject') + constraints),
-              mysql_engine=mysql_engine,
-              info=info)
+        table = Table(self._prefix+'DiaObject', self._metadata,
+                      *(self._tableColumns('DiaObject') + constraints),
+                      mysql_engine=mysql_engine,
+                      info=info)
+        self.objects = table
 
         if self._dia_object_nightly:
             # Same as DiaObject but no index
-            Table(self._prefix+'DiaObjectNightly', self._metadata,
-                  *self._tableColumns('DiaObject'),
-                  mysql_engine=mysql_engine,
-                  info=info)
+            table = Table(self._prefix+'DiaObjectNightly', self._metadata,
+                          *self._tableColumns('DiaObject'),
+                          mysql_engine=mysql_engine,
+                          info=info)
+            self.objects_nightly = table
 
         if self._dia_object_index == 'last_object_table':
             # Same as DiaObject but with special index
-            Table(self._prefix+'DiaObjectLast', self._metadata,
-                  *(self._tableColumns('DiaObject') +
-                    self._tableIndices('DiaObjectLast', info)),
-                  mysql_engine=mysql_engine,
-                  info=info)
+            table = Table(self._prefix+'DiaObjectLast', self._metadata,
+                          *(self._tableColumns('DiaObject') +
+                            self._tableIndices('DiaObjectLast', info)),
+                          mysql_engine=mysql_engine,
+                          info=info)
+            self.objects_last = table
 
         # for all other tables use index definitions in schema
         for table_name in ('DiaSource', 'SSObject', 'DiaForcedSource', 'DiaObject_To_Object_Match'):
-            Table(self._prefix+table_name, self._metadata,
-                  *(self._tableColumns(table_name) +
-                    self._tableIndices(table_name, info)),
-                  mysql_engine=mysql_engine,
-                  info=info)
+            table = Table(self._prefix+table_name, self._metadata,
+                          *(self._tableColumns(table_name) +
+                            self._tableIndices(table_name, info)),
+                          mysql_engine=mysql_engine,
+                          info=info)
+            if table_name == 'DiaSource':
+                self.sources = table
+            elif table_name == 'DiaForcedSource':
+                self.forcedSources = table
 
         # special table to track visits, only used by prototype
-        Table(self._prefix+'L1DbProtoVisits', self._metadata,
-              Column('visitId', sqlalchemy.types.BigInteger, nullable=False),
-              Column('visitTime', sqlalchemy.types.TIMESTAMP, nullable=False),
-              PrimaryKeyConstraint('visitId', name=self._prefix+'PK_L1DbProtoVisits'),
-              Index(self._prefix+'IDX_L1DbProtoVisits_vTime', 'visitTime', info=info),
-              mysql_engine=mysql_engine,
-              info=info)
+        table = Table(self._prefix+'L1DbProtoVisits', self._metadata,
+                      Column('visitId', sqlalchemy.types.BigInteger, nullable=False),
+                      Column('visitTime', sqlalchemy.types.TIMESTAMP, nullable=False),
+                      PrimaryKeyConstraint('visitId', name=self._prefix+'PK_L1DbProtoVisits'),
+                      Index(self._prefix+'IDX_L1DbProtoVisits_vTime', 'visitTime', info=info),
+                      mysql_engine=mysql_engine,
+                      info=info)
+        self.visits = table
+
+    def makeSchema(self, drop=False, mysql_engine='InnoDB', oracle_tablespace=None):
+        """Create or re-create all tables.
+
+        Parameters
+        ----------
+        drop : boolean, optional
+            If True then drop tables before creating new ones.
+        mysql_engine : `str`, optional
+            MySQL engine type to use for new tables.
+        oracle_tablespace : `str`, optional
+            Name of Oracle tablespace, only useful with oracle
+        """
+
+        # re-make table schema for all needed tables with possibly different options
+        self._metadata.clear()
+        self._makeTables(mysql_engine=mysql_engine, oracle_tablespace=oracle_tablespace)
 
         # create all tables (optionally drop first)
         if drop:
@@ -256,42 +305,6 @@ class L1dbSchema(object):
             self._metadata.drop_all()
         _LOG.info('creating all tables')
         self._metadata.create_all()
-
-    @property
-    def visits(self):
-        """SQLAlchemy `Table` instance for L1DbProtoVisits table.
-        """
-        return self._table_schema('L1DbProtoVisits')
-
-    @property
-    def objects(self):
-        """SQLAlchemy `Table` instance for DiaObject table.
-        """
-        return self._table_schema('DiaObject')
-
-    @property
-    def objects_last(self):
-        """SQLAlchemy `Table` instance for DiaObjectLast table.
-        """
-        return self._table_schema('DiaObjectLast')
-
-    @property
-    def objects_nightly(self):
-        """SQLAlchemy `Table` instance for DiaObjectNightly table.
-        """
-        return self._table_schema('DiaObjectNightly')
-
-    @property
-    def sources(self):
-        """SQLAlchemy `Table` instance for DiaSource table.
-        """
-        return self._table_schema('DiaSource')
-
-    @property
-    def forcedSources(self):
-        """SQLAlchemy `Table` instance for DiaForcedSource table.
-        """
-        return self._table_schema('DiaForcedSource')
 
     def getAfwSchema(self, table_name, columns=None):
         """Return afw schema for given table.
@@ -602,24 +615,3 @@ class L1dbSchema(object):
             return REAL
         else:
             raise TypeError('cannot determine DOUBLE type, unexpected dialect: ' + self._engine.name)
-
-    def _table_schema(self, name):
-        """Return SQLAlchemy schema for a table.
-
-        This does lazy reading of table schema from metadata.
-
-        Parameters
-        ----------
-        name : `str`
-            Table name.
-
-        Returns
-        -------
-        `sqlalchemy.Table` instance.
-        """
-        table = self._tables.get(name)
-        if table is None:
-            table = Table(self._prefix+name, self._metadata, autoload=True)
-            self._tables[name] = table
-            _LOG.debug("read table schema for %s: %s", name, table.c)
-        return table


### PR DESCRIPTION
Oracle does not like schema discovery (it runs very slow) so we don't do schema discovery anymore and rely on configuration. 
DiaObjectLast schema was made much narrower to save space and enable IOT for it.