### PR TITLE
DM-45449: Rename metrics published by jolokia2_agent.

### DIFF
--- a/misc/usdf-apdb-dev/etc/telegraf/telegraf.d/90-cassandra.conf
+++ b/misc/usdf-apdb-dev/etc/telegraf/telegraf.d/90-cassandra.conf
@@ -11,7 +11,6 @@
     name  = "GarbageCollector"
     mbean = "java.lang:name=*,type=GarbageCollector"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
 [[inputs.jolokia2_agent]]
   urls = ["http://localhost:8778/jolokia"]
@@ -21,76 +20,69 @@
     name  = "Cache"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=Cache"
     tag_keys = ["name", "scope"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Client"
     mbean = "org.apache.cassandra.metrics:name=*,type=Client"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ClientRequestMetrics"
     mbean = "org.apache.cassandra.metrics:name=*,type=ClientRequestMetrics"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ClientRequest"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=ClientRequest"
     tag_keys = ["name", "scope"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ColumnFamily"
     mbean = "org.apache.cassandra.metrics:keyspace=*,name=*,scope=*,type=ColumnFamily"
     tag_keys = ["keyspace", "name", "scope"]
-    field_prefix = "$2_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "CommitLog"
     mbean = "org.apache.cassandra.metrics:name=*,type=CommitLog"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Compaction"
     mbean = "org.apache.cassandra.metrics:name=*,type=Compaction"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "CQL"
     mbean = "org.apache.cassandra.metrics:name=*,type=CQL"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "DroppedMessage"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=DroppedMessage"
     tag_keys = ["name", "scope"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "FileCache"
     mbean = "org.apache.cassandra.metrics:name=*,type=FileCache"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ReadRepair"
     mbean = "org.apache.cassandra.metrics:name=*,type=ReadRepair"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Storage"
     mbean = "org.apache.cassandra.metrics:name=*,type=Storage"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ThreadPools"
     mbean = "org.apache.cassandra.metrics:name=*,path=*,scope=*,type=ThreadPools"
     tag_keys = ["name", "path", "scope"]
-    field_prefix = "$1_"
+
+# Run special processor to massage above metrics
+[[processors.execd]]
+
+  command = ["/usr/bin/python3", "/etc/telegraf/telegraf.d/cassandra-metrics-rename.py"]
+  restart_delay = "3s"

--- a/misc/usdf-apdb-dev/etc/telegraf/telegraf.d/cassandra-metrics-rename.py
+++ b/misc/usdf-apdb-dev/etc/telegraf/telegraf.d/cassandra-metrics-rename.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+_SPLIT_RE = re.compile(r"(?<!\\) ")
+
+_CONFIG = [
+    {
+        "measurement_pattern": re.compile("cassandra_.*"),
+        "tags": {"name"},
+        "replace": "{measurement_name}_{name}",
+        "remove_tags": {"name", "jolokia_agent_url"},
+    }
+]
+
+
+def main():
+    """Read metrics in influx line format, transform, and print."""
+    for line in sys.stdin:
+        try:
+            line = process_line(line)
+        except Exception:
+            sys.stderr.write("Failed to parse line " + line)
+        finally:
+            # Print original one if parsing/replacing raises.
+            sys.stdout.write(line)
+
+
+def process_line(line):
+    measurement, tags, rest = parse_influx(line)
+    if measurement is None:
+        return line
+    measurement, tags = replace(measurement, tags)
+    return measurement + "," + tags + " " + rest
+
+
+def parse_influx(line):
+    """Parse influx line and retyurn measurement name, tags and the rest of the
+    line.
+    """
+    # Measurement and tags are comma-spearated and are separated from the
+    # rest of the line by a space. Main problem here is that tag values can
+    # contain spaces. There are even weirder cases when names of tags can
+    # be quoted but I don't know how to handle that. For now assume that
+    # we do not have any quoted stuff which should be true for cassandra
+    # metrics.
+    parts = _SPLIT_RE.split(line, maxsplit=1)
+    if len(parts) != 2:
+        return None, None, None
+    measurement, _, tags_string = parts[0].partition(",")
+    rest = parts[1]
+    tags = [tag.split("=", 1) for tag in tags_string.split(",")]
+    return measurement, tags, rest
+
+
+def replace(measurement, tags):
+    for config in _CONFIG:
+        if config["measurement_pattern"].match(measurement):
+            tag_names = {tag[0] for tag in tags}
+            if config["tags"].issubset(tag_names):
+                subs = dict(tags, measurement_name=measurement)
+                measurement = config["replace"].format(**subs)
+                tags = [tag for tag in tags if tag[0] not in config["remove_tags"]]
+    tag_str = ",".join("=".join(tag) for tag in tags)
+    return measurement, tag_str
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/usdf-apdb-test/etc/telegraf/telegraf.d/90-cassandra.conf
+++ b/misc/usdf-apdb-test/etc/telegraf/telegraf.d/90-cassandra.conf
@@ -11,7 +11,6 @@
     name  = "GarbageCollector"
     mbean = "java.lang:name=*,type=GarbageCollector"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
 [[inputs.jolokia2_agent]]
   urls = ["http://localhost:8778/jolokia"]
@@ -21,76 +20,69 @@
     name  = "Cache"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=Cache"
     tag_keys = ["name", "scope"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Client"
     mbean = "org.apache.cassandra.metrics:name=*,type=Client"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ClientRequestMetrics"
     mbean = "org.apache.cassandra.metrics:name=*,type=ClientRequestMetrics"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ClientRequest"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=ClientRequest"
     tag_keys = ["name", "scope"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ColumnFamily"
     mbean = "org.apache.cassandra.metrics:keyspace=*,name=*,scope=*,type=ColumnFamily"
     tag_keys = ["keyspace", "name", "scope"]
-    field_prefix = "$2_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "CommitLog"
     mbean = "org.apache.cassandra.metrics:name=*,type=CommitLog"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Compaction"
     mbean = "org.apache.cassandra.metrics:name=*,type=Compaction"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "CQL"
     mbean = "org.apache.cassandra.metrics:name=*,type=CQL"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "DroppedMessage"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=DroppedMessage"
     tag_keys = ["name", "scope"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "FileCache"
     mbean = "org.apache.cassandra.metrics:name=*,type=FileCache"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ReadRepair"
     mbean = "org.apache.cassandra.metrics:name=*,type=ReadRepair"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Storage"
     mbean = "org.apache.cassandra.metrics:name=*,type=Storage"
     tag_keys = ["name"]
-    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ThreadPools"
     mbean = "org.apache.cassandra.metrics:name=*,path=*,scope=*,type=ThreadPools"
     tag_keys = ["name", "path", "scope"]
-    field_prefix = "$1_"
+
+# Run special processor to massage above metrics
+[[processors.execd]]
+
+  command = ["/usr/bin/python3", "/etc/telegraf/telegraf.d/cassandra-metrics-rename.py"]
+  restart_delay = "3s"

--- a/misc/usdf-apdb-test/etc/telegraf/telegraf.d/cassandra-metrics-rename.py
+++ b/misc/usdf-apdb-test/etc/telegraf/telegraf.d/cassandra-metrics-rename.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+_SPLIT_RE = re.compile(r"(?<!\\) ")
+
+_CONFIG = [
+    {
+        "measurement_pattern": re.compile("cassandra_.*"),
+        "tags": {"name"},
+        "replace": "{measurement_name}_{name}",
+        "remove_tags": {"name", "jolokia_agent_url"},
+    }
+]
+
+
+def main():
+    """Read metrics in influx line format, transform, and print."""
+    for line in sys.stdin:
+        try:
+            line = process_line(line)
+        except Exception:
+            sys.stderr.write("Failed to parse line " + line)
+        finally:
+            # Print original one if parsing/replacing raises.
+            sys.stdout.write(line)
+
+
+def process_line(line):
+    measurement, tags, rest = parse_influx(line)
+    if measurement is None:
+        return line
+    measurement, tags = replace(measurement, tags)
+    return measurement + "," + tags + " " + rest
+
+
+def parse_influx(line):
+    """Parse influx line and retyurn measurement name, tags and the rest of the
+    line.
+    """
+    # Measurement and tags are comma-spearated and are separated from the
+    # rest of the line by a space. Main problem here is that tag values can
+    # contain spaces. There are even weirder cases when names of tags can
+    # be quoted but I don't know how to handle that. For now assume that
+    # we do not have any quoted stuff which should be true for cassandra
+    # metrics.
+    parts = _SPLIT_RE.split(line, maxsplit=1)
+    if len(parts) != 2:
+        return None, None, None
+    measurement, _, tags_string = parts[0].partition(",")
+    rest = parts[1]
+    tags = [tag.split("=", 1) for tag in tags_string.split(",")]
+    return measurement, tags, rest
+
+
+def replace(measurement, tags):
+    for config in _CONFIG:
+        if config["measurement_pattern"].match(measurement):
+            tag_names = {tag[0] for tag in tags}
+            if config["tags"].issubset(tag_names):
+                subs = dict(tags, measurement_name=measurement)
+                measurement = config["replace"].format(**subs)
+                tags = [tag for tag in tags if tag[0] not in config["remove_tags"]]
+    tag_str = ",".join("=".join(tag) for tag in tags)
+    return measurement, tag_str
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
jolokia2_agent was puiblishing measurements with different sets of fields under the same name but with different tags. This resulted in a very large set of fields. Added a processor plugin execd which runs a simple python script renaming cassandra metrics by appending tag value. Also dropped all prefixes from flags in jolokia2_agent config.